### PR TITLE
Fixed radio button which was ignoring self events invalidly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.1.7] - January 12, 2023
+
+* Fixed radio button which was ignoring self events invalidly [Issue 117](https://github.com/peiffer-innovations/json_dynamic_widget/issues/117)
+
+
 ## [5.1.6+4] - January 10, 2023
 
 * Automated dependency updates

--- a/example/linux/flutter/CMakeLists.txt
+++ b/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/lib/src/builders/json_radio_builder.dart
+++ b/lib/src/builders/json_radio_builder.dart
@@ -236,8 +236,7 @@ class _JsonRadioWidgetState extends State<_JsonRadioWidget> {
 
     _subscriptions.add(
       widget.data.registry.valueStream
-          .where((event) =>
-              !event.isSelfTriggered && event.id == widget.builder.id)
+          .where((event) => event.id == widget.builder.id)
           .listen(
         (event) {
           if (mounted == true) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '5.1.6+4'
+version: '5.1.7'
 
 environment: 
   sdk: '>=2.18.0 <3.0.0'


### PR DESCRIPTION
## Description

Fix for the [issue-117](https://github.com/peiffer-innovations/json_dynamic_widget/issues/117)

@jpeiffer I think that radio button should respond to self events cause all radio has the same id


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
