### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.0.3+1] - March 13, 2023
+
+* Automated dependency updates
+
+
 ## [6.0.3] - March 9th, 2023
 
 * Allow for maxLines = null for TextFormField
@@ -496,4 +501,5 @@
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,57 +1,54 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+27'
+version: '1.0.0+28'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-dependencies:
+dependencies: 
   child_builder: '^2.0.1'
   desktop_window: '^0.4.0'
   dotted_border: '^2.0.0+3'
-  execution_timer: '^1.0.2'
-  flutter:
+  execution_timer: '^1.0.2+1'
+  flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.0+1'
-  json_class: '^2.1.5+1'
-  json_dynamic_widget:
+  flutter_svg: '^2.0.3'
+  json_class: '^2.1.6+1'
+  json_dynamic_widget: 
     path: '../'
-  json_theme: '^5.0.0'
+  json_theme: '^5.0.0+5'
   logging: '^1.1.1'
-  yaon: '^1.0.2'
+  yaon: '^1.0.2+1'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
 
-# dependency_overrides:
-#   scripted_test:
-#     path: ../../scripted_test
-#   scripted_test_cli:
-#     path: ../../scripted_test/packages/cli
-#   scripted_test_common:
-#     path: ../../scripted_test/packages/common
-#   scripted_test_plugin_desktop:
-#     path: ../../scripted_test/packages/desktop
 
-flutter:
+flutter: 
   uses-material-design: true
-  assets:
+  assets: 
     - 'assets/images/'
     - 'assets/pages/'
     - 'assets/secrets/'
     - 'assets/widgets/'
-  fonts:
-    - family: 'lato'
-      fonts:
-        - asset: 'assets/fonts/Lato-Regular.ttf'
+  fonts: 
+    - 
+      family: 'lato'
+      fonts: 
+        - 
+          asset: 'assets/fonts/Lato-Regular.ttf'
 
-    - family: 'metal'
-      fonts:
-        - asset: 'assets/fonts/MetalMania-Regular.ttf'
+    - 
+      family: 'metal'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MetalMania-Regular.ttf'
 
-ignore_updates:
+
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,57 +1,44 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '6.0.3'
+version: '6.0.3+1'
 
-environment:
+environment: 
   sdk: '>=2.19.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.1'
   collection: '^1.16.0'
-  execution_timer: '^1.0.2'
-  flutter:
+  execution_timer: '^1.0.2+1'
+  flutter: 
     sdk: 'flutter'
   form_validation: '^2.2.0+6'
   interpolation: '^2.1.2'
-  json_class: '^2.1.5+1'
-  json_conditional: '^2.1.1+1'
-  json_schema2: '^2.0.3+1'
-  json_theme: '^5.0.0'
+  json_class: '^2.1.6+1'
+  json_conditional: '^2.1.1+5'
+  json_schema2: '^2.0.3+5'
+  json_theme: '^5.0.0+5'
   logging: '^1.1.1'
   meta: '^1.8.0'
-  # Locked until one of these two issues is actually resolved as opposed to
-  # their effective finger pointing
-  #   -- https://github.com/flutter/flutter/issues/121391
-  #   -- https://github.com/petitparser/dart-petitparser/issues/144
-  petitparser: 5.1.0
-  template_expressions: '^2.2.1+1'
+  petitparser: '5.1.0'
+  template_expressions: '^2.2.1+4'
   uuid: '^3.0.7'
-  yaon: '^1.0.2'
+  yaon: '^1.0.2+1'
 
-false_secrets:
+false_secrets: 
   - 'example/web/index.html'
 
-dev_dependencies:
+dev_dependencies: 
   flutter_lints: '^2.0.1'
-  flutter_test:
+  flutter_test: 
     sdk: 'flutter'
 
-# dependency_overrides:
-#   scripted_test:
-#     path: ../scripted_test
-#   scripted_test_cli:
-#     path: ../scripted_test/packages/cli
-#   scripted_test_common:
-#     path: ../scripted_test/packages/common
-#   scripted_test_plugin_desktop:
-#     path: ../scripted_test/packages/desktop
-
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `execution_timer`: 1.0.2 --> 1.0.2+1
  * `json_class`: 2.1.5+1 --> 2.1.6+1
  * `json_conditional`: 2.1.1+1 --> 2.1.1+5
  * `json_schema2`: 2.0.3+1 --> 2.0.3+5
  * `json_theme`: 5.0.0 --> 5.0.0+5
  * `template_expressions`: 2.2.1+1 --> 2.2.1+4
  * `yaon`: 1.0.2 --> 1.0.2+1


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Running "flutter pub get" in flutter_tools...
Resolving dependencies in ../../../../../opt/hostedtoolcache/flutter/3.7.7-stable/x64/packages/flutter_tools...
  _fe_analyzer_shared 50.0.0 (55.0.0 available)
  analyzer 5.2.0 (5.7.1 available)
  archive 3.3.2 (3.3.6 available)
  args 2.3.1 (2.4.0 available)
  async 2.10.0 (2.11.0 available)
  built_value 8.4.2 (8.4.4 available)
  checked_yaml 2.0.1 (2.0.2 available)
  collection 1.17.0 (1.17.1 available)
  completion 1.0.0 (1.0.1 available)
  coverage 1.6.1 (1.6.3 available)
  dds 2.5.0 (2.7.6 available)
  dds_service_extensions 1.3.1 (1.3.3 available)
  devtools_shared 2.18.0 (2.22.2 available)
  dwds 16.0.2+1 (18.0.0 available)
  fixnum 1.0.1 (1.1.0 available)
  frontend_server_client 3.1.0 (3.2.0 available)
  html 0.15.1 (0.15.2 available)
  intl 0.17.0 (0.18.0 available)
  io 1.0.3 (1.0.4 available)
  js 0.6.5 (0.6.7 available)
  json_annotation 4.7.0 (4.8.0 available)
  logging 1.1.0 (1.1.1 available)
  matcher 0.12.13 (0.12.14 available)
  meta 1.8.0 (1.9.0 available)
  mime 1.0.2 (1.0.4 available)
  multicast_dns 0.3.2+2 (0.3.2+3 available)
  native_stack_traces 0.5.2 (0.5.5 available)
  node_preamble 2.0.1 (2.0.2 available)
  path 1.8.2 (1.8.3 available)
  petitparser 5.1.0 (5.3.0 available)
  pubspec_parse 1.2.1 (1.2.2 available)
  source_maps 0.10.11 (0.10.12 available)
  sse 4.1.1 (4.1.2 available)
  test 1.22.0 (1.23.1 available)
  test_api 0.4.16 (0.4.18 available)
  test_core 0.4.20 (0.4.24 available)
  vm_service 9.4.0 (11.2.0 available)
  web_socket_channel 2.2.0 (2.3.0 available)
  webdriver 3.0.1 (3.0.2 available)
Got dependencies in ../../../../../opt/hostedtoolcache/flutter/3.7.7-stable/x64/packages/flutter_tools!
Running "flutter pub get" in json_dynamic_widget...
Resolving dependencies...


Because template_expressions >=2.2.1+4 depends on petitparser ^5.3.0 and json_dynamic_widget depends on petitparser 5.1.0, template_expressions >=2.2.1+4 is forbidden.
So, because json_dynamic_widget depends on template_expressions ^2.2.1+4, version solving failed.
pub get failed
command: "/opt/hostedtoolcache/flutter/3.7.7-stable/x64/bin/cache/dart-sdk/bin/dart __deprecated_pub --directory . get --example"
pub env: {
  "FLUTTER_ROOT": "/opt/hostedtoolcache/flutter/3.7.7-stable/x64",
  "PUB_ENVIRONMENT": "flutter_bot:flutter_cli:get",
  "PUB_CACHE": "/opt/hostedtoolcache/flutter/3.7.7-stable/x64/.pub-cache",
}
exit code: 1


```


dependencies:
  * `execution_timer`: 1.0.2 --> 1.0.2+1
  * `flutter_svg`: 2.0.0+1 --> 2.0.3
  * `json_class`: 2.1.5+1 --> 2.1.6+1
  * `json_theme`: 5.0.0 --> 5.0.0+5
  * `yaon`: 1.0.2 --> 1.0.2+1


Error!!!
```
Running "flutter pub get" in example...
Resolving dependencies...


Because template_expressions >=2.2.1+4 depends on petitparser ^5.3.0 and every version of json_dynamic_widget from path depends on petitparser 5.1.0, template_expressions >=2.2.1+4 is incompatible with json_dynamic_widget from path.
So, because example depends on json_dynamic_widget from path which depends on template_expressions ^2.2.1+4, version solving failed.
pub get failed
command: "/opt/hostedtoolcache/flutter/3.7.7-stable/x64/bin/cache/dart-sdk/bin/dart __deprecated_pub --directory . get --example"
pub env: {
  "FLUTTER_ROOT": "/opt/hostedtoolcache/flutter/3.7.7-stable/x64",
  "PUB_ENVIRONMENT": "flutter_bot:flutter_cli:get",
  "PUB_CACHE": "/opt/hostedtoolcache/flutter/3.7.7-stable/x64/.pub-cache",
}
exit code: 1


```

