### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+36'
+version: '1.0.0+37'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -13,7 +13,7 @@ dependencies:
   execution_timer: '^1.0.2+4'
   flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.5'
+  flutter_svg: '^2.0.6'
   json_class: '^2.2.1+3'
   json_dynamic_widget: 
     path: '../'


### PR DESCRIPTION
PR created automatically



dependencies:
  * `flutter_svg`: 2.0.5 --> 2.0.6


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Because every version of json_dynamic_widget from path depends on template_expressions ^3.0.2+1 which depends on petitparser 5.1.0, every version of json_dynamic_widget from path requires petitparser 5.1.0.
And because xml >=6.3.0 depends on petitparser ^5.4.0, json_dynamic_widget from path is incompatible with xml >=6.3.0.
And because flutter_svg >=2.0.6 depends on vector_graphics_compiler ^1.1.6 which depends on xml ^6.3.0, json_dynamic_widget from path is incompatible with flutter_svg >=2.0.6.
So, because example depends on both flutter_svg ^2.0.6 and json_dynamic_widget from path, version solving failed.

```

