### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.0.5+4] - June 13, 2023
+
+* Automated dependency updates
+
+
 ## [6.0.5+3] - May 30, 2023
 
 * Automated dependency updates
@@ -557,6 +562,7 @@
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+37'
+version: '1.0.0+38'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -13,11 +13,11 @@ dependencies:
   execution_timer: '^1.0.2+4'
   flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.6'
+  flutter_svg: '^2.0.7'
   json_class: '^2.2.1+3'
   json_dynamic_widget: 
     path: '../'
-  json_theme: '^5.0.2+6'
+  json_theme: '^6.0.0'
   logging: '^1.2.0'
   yaon: '^1.1.1'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '6.0.5+3'
+version: '6.0.5+4'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -17,15 +17,15 @@ dependencies:
   execution_timer: '^1.0.2+4'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^3.0.0'
+  form_validation: '^3.0.1'
   interpolation: '^2.1.2'
   json_class: '^2.2.1+3'
   json_conditional: '^2.1.1+11'
-  json_schema2: '^2.0.4+8'
-  json_theme: '^5.0.2+6'
+  json_schema2: '^2.0.4+9'
+  json_theme: '^6.0.0'
   logging: '^1.2.0'
   meta: '^1.8.0'
-  template_expressions: '^3.0.4+1'
+  template_expressions: '^3.0.5'
   uuid: '^3.0.7'
   yaon: '^1.1.1'
 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `form_validation`: 3.0.0 --> 3.0.1
  * `json_schema2`: 2.0.4+8 --> 2.0.4+9
  * `json_theme`: 5.0.2+6 --> 6.0.0
  * `template_expressions`: 3.0.4+1 --> 3.0.5


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
+ args 2.4.2
+ asn1lib 1.4.0
+ async 2.11.0
+ boolean_selector 2.1.1
+ characters 1.3.0
+ child_builder 2.0.1
+ clock 1.1.1
+ collection 1.17.1 (1.17.2 available)
+ convert 3.1.1
+ crypto 3.0.3
+ encrypt 5.0.1
+ execution_timer 1.0.2+4
+ fake_async 1.3.1
+ flutter 0.0.0 from sdk flutter
+ flutter_lints 2.0.1
+ flutter_test 0.0.0 from sdk flutter
+ form_validation 3.0.1
+ http 0.13.6 (1.0.0 available)
+ http_parser 4.0.2
+ interpolation 2.1.2
+ intl 0.18.1
+ iregexp 0.1.1
+ js 0.6.7
+ json_class 2.2.1+3
+ json_conditional 2.1.1+11
+ json_path 0.6.0
+ json_schema 5.1.1
+ json_schema2 2.0.4+9 (discontinued replaced by json_schema)
+ json_theme 6.0.0
+ lints 2.1.1
+ logging 1.2.0
+ matcher 0.12.15 (0.12.16 available)
+ material_color_utilities 0.2.0 (0.5.0 available)
+ maybe_just_nothing 0.5.3
+ meta 1.9.1
+ path 1.8.3
+ petitparser 5.4.0
+ pointycastle 3.7.3
+ quiver 3.2.1
+ rest_client 2.2.1+11
+ rfc_6901 0.1.1
+ rxdart 0.27.7
+ sky_engine 0.0.99 from sdk flutter
+ source_span 1.9.1 (1.10.0 available)
+ stack_trace 1.11.0
+ stream_channel 2.1.1
+ string_scanner 1.2.0
+ template_expressions 3.0.5
+ term_glyph 1.2.1
+ test_api 0.5.1 (0.6.0 available)
+ typed_data 1.3.2
+ uri 1.0.0
+ uuid 3.0.7
+ vector_math 2.1.4
+ yaml 3.1.2
+ yaon 1.1.1
Changed 56 dependencies!
Resolving dependencies in ./example...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Because example depends on json_dynamic_widget from path which depends on json_theme ^6.0.0, json_theme ^6.0.0 is required.
So, because example depends on json_theme ^5.0.2+6, version solving failed.

```


dependencies:
  * `flutter_svg`: 2.0.6 --> 2.0.7
  * `json_theme`: 5.0.2+6 --> 6.0.0


Analysis Successful

