### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.0.6+5] - July 4, 2023
+
+* Automated dependency updates
+
+
 ## [6.0.6+4] - June 27, 2023
 
 * Automated dependency updates
@@ -573,6 +578,7 @@
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+39'
+version: '1.0.0+40'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -10,16 +10,16 @@ dependencies:
   child_builder: '^2.0.1'
   desktop_window: '^0.4.0'
   dotted_border: '^2.0.0+3'
-  execution_timer: '^1.0.3'
+  execution_timer: '^1.0.3+1'
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.7'
-  json_class: '^2.2.2'
+  json_class: '^2.2.2+1'
   json_dynamic_widget: 
     path: '../'
   json_theme: '^6.0.1+1'
   logging: '^1.2.0'
-  yaon: '^1.1.2'
+  yaon: '^1.1.2+1'
 
 dev_dependencies: 
   flutter_test: 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '6.0.6+4'
+version: '6.0.6+5'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -14,23 +14,23 @@ analyzer:
 dependencies: 
   child_builder: '^2.0.1'
   collection: '^1.16.0'
-  execution_timer: '^1.0.3'
+  execution_timer: '^1.0.3+1'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^3.0.2+1'
+  form_validation: '^3.0.2+2'
   interpolation: '^2.1.2'
-  json_class: '^2.2.2'
-  json_conditional: '^2.1.2+1'
+  json_class: '^2.2.2+1'
+  json_conditional: '^2.1.2+2'
   json_schema2: '^5.1.2+2'
   json_theme: '^6.0.1+1'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.0.6+1'
+  template_expressions: '^3.0.6+2'
   uuid: '^3.0.7'
-  yaon: '^1.1.2'
+  yaon: '^1.1.2+1'
 
 dev_dependencies: 
-  flutter_lints: '^2.0.1'
+  flutter_lints: '^2.0.2'
   flutter_test: 
     sdk: 'flutter'
 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `execution_timer`: 1.0.3 --> 1.0.3+1
  * `form_validation`: 3.0.2+1 --> 3.0.2+2
  * `json_class`: 2.2.2 --> 2.2.2+1
  * `json_conditional`: 2.1.2+1 --> 2.1.2+2
  * `template_expressions`: 3.0.6+1 --> 3.0.6+2
  * `yaon`: 1.1.2 --> 1.1.2+1

dev_dependencies:
  * `flutter_lints`: 2.0.1 --> 2.0.2


Analysis Successful


dependencies:
  * `execution_timer`: 1.0.3 --> 1.0.3+1
  * `json_class`: 2.2.2 --> 2.2.2+1
  * `yaon`: 1.1.2 --> 1.1.2+1


Analysis Successful

