### PR TITLE
chore: nullability of ClipRRect.borderRadius in Flutter 3.13.0

### DIFF
--- a/lib/src/builders/json_clip_rrect_builder.dart
+++ b/lib/src/builders/json_clip_rrect_builder.dart
@@ -7,7 +7,7 @@ import 'package:json_theme/json_theme.dart';
 /// format.
 class JsonClipRRectBuilder extends JsonWidgetBuilder {
   const JsonClipRRectBuilder({
-    this.borderRadius,
+    required this.borderRadius,
     required this.clipBehavior,
     this.clipper,
   }) : super(numSupportedChildren: kNumSupportedChildren);
@@ -15,7 +15,7 @@ class JsonClipRRectBuilder extends JsonWidgetBuilder {
   static const kNumSupportedChildren = 1;
   static const type = 'clip_rrect';
 
-  final BorderRadius? borderRadius;
+  final BorderRadius borderRadius;
   final Clip clipBehavior;
   final CustomClipper<RRect>? clipper;
 


### PR DESCRIPTION
ClipRRect.borderRadius is non-nullable in Flutter 3.13.0
