### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.1.2+2] - August 29, 2023
+
+* Automated dependency updates
+
+
 ## [6.1.2+1] - August 22, 2023
 
 * Automated dependency updates
@@ -622,6 +627,7 @@
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '6.1.2+1'
+version: '6.1.2+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -25,7 +25,7 @@ dependencies:
   json_theme: '^6.2.3'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.1+1'
+  template_expressions: '^3.1.1+2'
   uuid: '^3.0.7'
   yaon: '^1.1.2+3'
 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `template_expressions`: 3.1.1+1 --> 3.1.1+2


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Because template_expressions >=3.1.1+2 depends on json_path ^0.6.4 which depends on rfc_6901 ^0.2.0, template_expressions >=3.1.1+2 requires rfc_6901 ^0.2.0.
And because json_schema >=5.0.0-rc2 depends on rfc_6901 ^0.1.0, template_expressions >=3.1.1+2 is incompatible with json_schema >=5.0.0-rc2.
So, because json_dynamic_widget depends on both json_schema ^5.1.2 and template_expressions ^3.1.1+2, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on template_expressions: flutter pub add template_expressions:'^3.1.1+1'

```


