### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.1.2+2] - September 5, 2023
+
+* Automated dependency updates
+
+
 ## [6.1.2+1] - August 22, 2023
 
 * Automated dependency updates
@@ -622,6 +627,7 @@
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+45'
+version: '1.0.0+46'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -10,14 +10,14 @@ dependencies:
   child_builder: '^2.0.1'
   desktop_window: '^0.4.0'
   dotted_border: '^2.0.0+3'
-  execution_timer: '^1.0.3+3'
+  execution_timer: '^1.0.3+4'
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.7'
-  json_class: '^3.0.0+3'
+  json_class: '^3.0.0+4'
   json_dynamic_widget: 
     path: '../'
-  json_theme: '^6.2.3'
+  json_theme: '^6.2.4'
   logging: '^1.2.0'
   yaon: '^1.1.2+3'
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '6.1.2+1'
+version: '6.1.2+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -14,23 +14,23 @@ analyzer:
 dependencies: 
   child_builder: '^2.0.1'
   collection: '^1.17.1'
-  execution_timer: '^1.0.3+3'
+  execution_timer: '^1.0.3+4'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.0+3'
+  form_validation: '^3.1.0+4'
   interpolation: '^2.1.2'
-  json_class: '^3.0.0+3'
+  json_class: '^3.0.0+4'
   json_conditional: '^3.0.0+5'
   json_schema: '^5.1.2'
-  json_theme: '^6.2.3'
+  json_theme: '^6.2.4'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.1+1'
-  uuid: '^3.0.7'
+  template_expressions: '^3.1.1+3'
+  uuid: '^4.0.0'
   yaon: '^1.1.2+3'
 
 dev_dependencies: 
-  flutter_lints: '^2.0.2'
+  flutter_lints: '^2.0.3'
   flutter_test: 
     sdk: 'flutter'
 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `execution_timer`: 1.0.3+3 --> 1.0.3+4
  * `form_validation`: 3.1.0+3 --> 3.1.0+4
  * `json_class`: 3.0.0+3 --> 3.0.0+4
  * `json_theme`: 6.2.3 --> 6.2.4
  * `template_expressions`: 3.1.1+1 --> 3.1.1+3
  * `uuid`: 3.0.7 --> 4.0.0

dev_dependencies:
  * `flutter_lints`: 2.0.2 --> 2.0.3


Error!!!
```
Resolving dependencies...
  _fe_analyzer_shared 61.0.0 (64.0.0 available)
  analyzer 5.13.0 (6.2.0 available)
  archive 3.3.2 (3.3.8 available)
  args 2.4.2
  async 2.11.0
  boolean_selector 2.1.1
  browser_launcher 1.1.1
  built_collection 5.1.1
  built_value 8.6.1 (8.6.2 available)
  checked_yaml 2.0.3
  clock 1.1.1
  collection 1.17.2 (1.18.0 available)
  completion 1.0.1
  convert 3.1.1
  coverage 1.6.3
  crypto 3.0.3
  csslib 1.0.0
  dap 1.0.0 (1.1.0 available)
  dds 2.9.0+hotfix (2.9.4 available)
  dds_service_extensions 1.5.0 (1.6.0 available)
  devtools_shared 2.24.0 (3.0.1 available)
  dwds 19.0.1+1 (20.0.1 available)
  fake_async 1.3.1
  file 6.1.4 (7.0.0 available)
  file_testing 3.0.0
  fixnum 1.1.0
  flutter_template_images 4.2.0 (4.2.1 available)
  frontend_server_client 3.2.0
  glob 2.1.2
  html 0.15.4
  http 0.13.6 (1.1.0 available)
  http_multi_server 3.2.1
  http_parser 4.0.2
  intl 0.18.1
  io 1.0.4
  js 0.6.7
  json_annotation 4.8.1
  json_rpc_2 3.0.2
  logging 1.2.0
  matcher 0.12.16
  meta 1.9.1
  mime 1.0.4
  multicast_dns 0.3.2+3 (0.3.2+4 available)
  mustache_template 2.0.0
  native_stack_traces 0.5.6
  node_preamble 2.0.2
  package_config 2.1.0
  path 1.8.3
  petitparser 5.4.0 (6.0.1 available)
  platform 3.1.0 (3.1.2 available)
  pool 1.5.1
  process 4.2.4 (5.0.0 available)
  pub_semver 2.1.4
  pubspec_parse 1.2.3
  shelf 1.4.1
  shelf_packages_handler 3.0.2
  shelf_proxy 1.0.4
  shelf_static 1.1.2
  shelf_web_socket 1.0.4
  source_map_stack_trace 2.1.1
  source_maps 0.10.12
  source_span 1.10.0
  sse 4.1.2
  stack_trace 1.11.0 (1.11.1 available)
  standard_message_codec 0.0.1+3 (0.0.1+4 available)
  stream_channel 2.1.1 (2.1.2 available)
  string_scanner 1.2.0
  sync_http 0.3.1
  term_glyph 1.2.1
  test 1.24.3 (1.24.6 available)
  test_api 0.6.0 (0.6.1 available)
  test_core 0.5.3 (0.5.6 available)
  typed_data 1.3.2
  unified_analytics 2.0.0 (3.0.0 available)
  usage 4.1.1
  uuid 3.0.7 (4.0.0 available)
  vm_service 11.7.1 (11.10.0 available)
  vm_snapshot_analysis 0.7.2 (0.7.6 available)
  watcher 1.1.0
  web_socket_channel 2.4.0
  webdriver 3.0.2
  webkit_inspection_protocol 1.2.0 (1.2.1 available)
  xml 6.3.0 (6.4.2 available)
  yaml 3.1.2
No dependencies changed.
29 packages have newer versions incompatible with dependency constraints.
Try `dart pub outdated` for more information.
Resolving dependencies...


Building flutter tool...
Because template_expressions >=3.1.1+2 depends on json_path ^0.6.4 which depends on rfc_6901 ^0.2.0, template_expressions >=3.1.1+2 requires rfc_6901 ^0.2.0.
And because json_schema >=5.0.0-rc2 depends on rfc_6901 ^0.1.0, template_expressions >=3.1.1+2 is incompatible with json_schema >=5.0.0-rc2.
So, because json_dynamic_widget depends on both json_schema ^5.1.2 and template_expressions ^3.1.1+3, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on template_expressions: flutter pub add template_expressions:'^3.1.1+1'

```


dependencies:
  * `execution_timer`: 1.0.3+3 --> 1.0.3+4
  * `json_class`: 3.0.0+3 --> 3.0.0+4
  * `json_theme`: 6.2.3 --> 6.2.4


Error!!!
```
Resolving dependencies...


Because every version of json_dynamic_widget from path depends on json_schema ^5.1.2 which depends on rfc_6901 ^0.1.0, every version of json_dynamic_widget from path requires rfc_6901 ^0.1.0.
And because template_expressions >=3.1.1+2 depends on json_path ^0.6.4 which depends on rfc_6901 ^0.2.0, json_dynamic_widget from path is incompatible with template_expressions >=3.1.1+2.
So, because example depends on json_dynamic_widget from path which depends on template_expressions ^3.1.1+3, version solving failed.

```

