### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.0+2] - October 17, 2023
+
+* Automated dependency updates
+
+
 ## [1.1.0+1] - October 3, 2023
 
 * Automated dependency updates
@@ -11,4 +16,5 @@
 ## [1.0.0] - August 12th, 2023
 
 * Initial release
+
 

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.0+1'
+version: '1.1.0+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies: 
   flutter_lints: '^2.0.3'
-  test: '^1.24.7'
+  test: '^1.24.8'
 
 ignore_updates: 
   - 'archive'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.1+2] - October 17, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.1+1] - October 3, 2023
 
 * Automated dependency updates
@@ -24,4 +29,5 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.1+1'
+version: '1.0.1+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -13,21 +13,21 @@ analyzer:
 
 
 dependencies: 
-  analyzer: '^6.2.0'
+  analyzer: '^6.3.0'
   build: '^2.4.1'
   code_builder: '^4.7.0'
-  dynamic_widget_annotation: '^1.1.0'
+  dynamic_widget_annotation: '^1.1.0+1'
   json_class: '^3.0.0+5'
   json_theme: '^6.3.0'
   recase: '^4.1.0'
   source_gen: '^1.4.0'
-  template_expressions: '^3.1.2+2'
+  template_expressions: '^3.1.2+3'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+5'
 
 dev_dependencies: 
   flutter_lints: '^2.0.3'
-  test: '^1.24.7'
+  test: '^1.24.8'
 
 ignore_updates: 
   - 'archive'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.2+1] - October 17, 2023
+
+* Automated dependency updates
+
+
 ## [7.0.2] - October 8th, 2023
 
 * Fix for [Issue 220](https://github.com/peiffer-innovations/json_dynamic_widget/issues/220)
@@ -676,6 +681,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+43'
+version: '1.0.0+44'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -10,7 +10,7 @@ dependencies:
   child_builder: '^2.0.1'
   desktop_window: '^0.4.0'
   dotted_border: '^2.1.0'
-  execution_timer: '^1.0.3+5'
+  execution_timer: '^1.0.3+6'
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.7'
@@ -19,7 +19,7 @@ dependencies:
     path: '../'
   json_theme: '^6.3.0'
   logging: '^1.2.0'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+5'
 
 dev_dependencies: 
   build_runner: '^2.4.6'
@@ -27,7 +27,7 @@ dev_dependencies:
   flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.4'
-  json_dynamic_widget_codegen: '^1.0.1'
+  json_dynamic_widget_codegen: '^1.0.1+1'
   yaml_writer: '^1.0.3'
 
 icons_launcher: 

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,43 +1,44 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.2'
+version: '7.0.2+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.1'
   collection: '^1.17.1'
-  dynamic_widget_annotation: '^1.1.0'
-  execution_timer: '^1.0.3+5'
-  flutter:
+  dynamic_widget_annotation: '^1.1.0+1'
+  execution_timer: '^1.0.3+6'
+  flutter: 
     sdk: 'flutter'
   form_validation: '^3.1.0+5'
   interpolation: '^2.1.2'
   json_class: '^3.0.0+5'
-  json_conditional: '^3.0.0+7'
+  json_conditional: '^3.0.0+9'
   json_schema: '^5.1.3'
   json_theme: '^6.3.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.2+2'
+  template_expressions: '^3.1.2+3'
   uuid: '^4.1.0'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+5'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.4.6'
   flutter_lints: '^2.0.3'
-  flutter_test:
+  flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.1'
+  json_dynamic_widget_codegen: '^1.0.1+1'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.24.7 --> 1.24.8


Analysis Successful


dependencies:
  * `analyzer`: 6.2.0 --> 6.3.0
  * `dynamic_widget_annotation`: 1.1.0 --> 1.1.0+1
  * `template_expressions`: 3.1.2+2 --> 3.1.2+3
  * `yaon`: 1.1.2+4 --> 1.1.2+5

dev_dependencies:
  * `test`: 1.24.7 --> 1.24.8


Error!!!
```
Resolving dependencies...


Note: meta is pinned to version 1.9.1 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because json_theme >=2.0.0 depends on flutter from sdk which depends on meta 1.9.1, json_theme >=2.0.0 requires meta 1.9.1.
And because analyzer >=6.3.0 depends on meta ^1.11.0, json_theme >=2.0.0 is incompatible with analyzer >=6.3.0.
So, because json_dynamic_widget_codegen depends on both analyzer ^6.3.0 and json_theme ^6.3.0, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on analyzer: dart pub add analyzer:^6.2.0

```


dependencies:
  * `dynamic_widget_annotation`: 1.1.0 --> 1.1.0+1
  * `execution_timer`: 1.0.3+5 --> 1.0.3+6
  * `json_conditional`: 3.0.0+7 --> 3.0.0+9
  * `template_expressions`: 3.1.2+2 --> 3.1.2+3
  * `yaon`: 1.1.2+4 --> 1.1.2+5

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.1 --> 1.0.1+1


Analysis Successful


dependencies:
  * `execution_timer`: 1.0.3+5 --> 1.0.3+6
  * `yaon`: 1.1.2+4 --> 1.1.2+5

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.1 --> 1.0.1+1


Analysis Successful

