### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.0+2] - October 24, 2023
+
+* Automated dependency updates
+
+
 ## [1.1.0+1] - October 3, 2023
 
 * Automated dependency updates
@@ -11,4 +16,5 @@
 ## [1.0.0] - August 12th, 2023
 
 * Initial release
+
 

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.0+1'
+version: '1.1.0+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -16,8 +16,8 @@ dependencies:
   meta: '^1.9.1'
 
 dev_dependencies: 
-  flutter_lints: '^2.0.3'
-  test: '^1.24.7'
+  flutter_lints: '^3.0.0'
+  test: '^1.24.8'
 
 ignore_updates: 
   - 'archive'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.2+1] - October 24, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.2] - October 18th, 2023
 
 * Updated to call `super.register` if it exists on the registrar
@@ -30,4 +35,5 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,34 +1,35 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.2'
+version: '1.0.2+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
+
+dependencies: 
   analyzer: '^6.2.0'
   build: '^2.4.1'
   code_builder: '^4.7.0'
   dynamic_widget_annotation: '^1.1.0+1'
-  json_class: '^3.0.0+5'
+  json_class: '^3.0.0+6'
   json_theme: '^6.3.0'
   recase: '^4.1.0'
   source_gen: '^1.4.0'
-  template_expressions: '^3.1.2+3'
+  template_expressions: '^3.1.4+1'
   yaml_writer: '^1.0.3'
   yaon: '^1.1.2+5'
 
-dev_dependencies:
-  flutter_lints: '^2.0.3'
+dev_dependencies: 
+  flutter_lints: '^3.0.0'
   test: '^1.24.8'
 
-ignore_updates:
+ignore_updates: 
   - 'analyzer'
   - 'archive'
   - 'async'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.3+1] - October 24, 2023
+
+* Automated dependency updates
+
+
 ## [7.0.3] - October 18th, 2023
 
 * Regenerated code based off of some fixes from the code generator package.
@@ -681,6 +686,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,72 +1,80 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+43'
+version: '1.0.0+44'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
+dependencies: 
   child_builder: '^2.0.1'
   desktop_window: '^0.4.0'
   dotted_border: '^2.1.0'
-  execution_timer: '^1.0.3+5'
-  flutter:
+  execution_timer: '^1.0.3+7'
+  flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.7'
-  json_class: '^3.0.0+5'
-  json_dynamic_widget:
+  json_class: '^3.0.0+6'
+  json_dynamic_widget: 
     path: '../'
   json_theme: '^6.3.0'
   logging: '^1.2.0'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+5'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.4.6'
-  flutter_lints: '^2.0.3'
-  flutter_test:
+  flutter_lints: '^3.0.0'
+  flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.4'
-  json_dynamic_widget_codegen: '^1.0.1'
+  json_dynamic_widget_codegen: '^1.0.2'
   yaml_writer: '^1.0.3'
 
-dependency_overrides:
-  json_dynamic_widget_codegen:
-    path: ../../codegen
+dependency_overrides: 
+  json_dynamic_widget_codegen: 
+    path: '../../codegen'
 
-icons_launcher:
+
+icons_launcher: 
   image_path: 'assets-src/icon.png'
-  platforms:
-    android:
+  platforms: 
+    android: 
       enable: true
-    ios:
+    ios: 
       enable: true
-    linux:
+    linux: 
       enable: true
-    macos:
+    macos: 
       enable: true
-    web:
+    web: 
       enable: true
-    windows:
+    windows: 
       enable: true
 
-flutter:
+
+flutter: 
   uses-material-design: true
-  assets:
+  assets: 
     - 'assets/images/'
     - 'assets/pages/'
     - 'assets/secrets/'
     - 'assets/widgets/'
-  fonts:
-    - family: 'lato'
-      fonts:
-        - asset: 'assets/fonts/Lato-Regular.ttf'
+  fonts: 
+    - 
+      family: 'lato'
+      fonts: 
+        - 
+          asset: 'assets/fonts/Lato-Regular.ttf'
 
-    - family: 'metal'
-      fonts:
-        - asset: 'assets/fonts/MetalMania-Regular.ttf'
+    - 
+      family: 'metal'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MetalMania-Regular.ttf'
 
-ignore_updates:
+
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,47 +1,49 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.3'
+version: '7.0.3+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.1'
   collection: '^1.17.1'
-  dynamic_widget_annotation: '^1.1.0'
-  execution_timer: '^1.0.3+5'
-  flutter:
+  dynamic_widget_annotation: '^1.1.0+1'
+  execution_timer: '^1.0.3+7'
+  flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.0+5'
+  form_validation: '^3.1.0+6'
   interpolation: '^2.1.2'
-  json_class: '^3.0.0+5'
-  json_conditional: '^3.0.0+7'
+  json_class: '^3.0.0+6'
+  json_conditional: '^3.0.0+9'
   json_schema: '^5.1.3'
   json_theme: '^6.3.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.2+2'
+  template_expressions: '^3.1.4+1'
   uuid: '^4.1.0'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+5'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.4.6'
-  flutter_lints: '^2.0.3'
-  flutter_test:
+  flutter_lints: '^3.0.0'
+  flutter_test: 
     sdk: 'flutter'
   json_dynamic_widget_codegen: '^1.0.2'
 
-dependency_overrides:
-  json_dynamic_widget_codegen:
-    path: ../codegen
+dependency_overrides: 
+  json_dynamic_widget_codegen: 
+    path: '../codegen'
 
-ignore_updates:
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `flutter_lints`: 2.0.3 --> 3.0.0
  * `test`: 1.24.7 --> 1.24.8


Analysis Successful


dependencies:
  * `json_class`: 3.0.0+5 --> 3.0.0+6
  * `template_expressions`: 3.1.2+3 --> 3.1.4+1

dev_dependencies:
  * `flutter_lints`: 2.0.3 --> 3.0.0


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.0 --> 1.1.0+1
  * `execution_timer`: 1.0.3+5 --> 1.0.3+7
  * `form_validation`: 3.1.0+5 --> 3.1.0+6
  * `json_class`: 3.0.0+5 --> 3.0.0+6
  * `json_conditional`: 3.0.0+7 --> 3.0.0+9
  * `template_expressions`: 3.1.2+2 --> 3.1.4+1
  * `yaon`: 1.1.2+4 --> 1.1.2+5

dev_dependencies:
  * `flutter_lints`: 2.0.3 --> 3.0.0


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
+ _fe_analyzer_shared 64.0.0 (65.0.0 available)
+ analyzer 6.2.0 (6.3.0 available)
+ args 2.4.2
+ asn1lib 1.5.0
+ async 2.11.0
+ boolean_selector 2.1.1
+ build 2.4.1
+ build_config 1.1.1
+ build_daemon 4.0.0
+ build_resolvers 2.4.1
+ build_runner 2.4.6
+ build_runner_core 7.2.11
+ built_collection 5.1.1
+ built_value 8.6.3
+ characters 1.3.0
+ checked_yaml 2.0.3
+ child_builder 2.0.1
+ clock 1.1.1
+ code_builder 4.7.0
+ collection 1.17.2 (1.18.0 available)
+ convert 3.1.1
+ crypto 3.0.3
+ dart_style 2.3.3
+ dynamic_widget_annotation 1.1.0+1
+ encrypt 5.0.3
+ execution_timer 1.0.3+7
+ fake_async 1.3.1
+ file 7.0.0
+ fixnum 1.1.0
+ flutter 0.0.0 from sdk flutter
+ flutter_lints 3.0.0
+ flutter_test 0.0.0 from sdk flutter
+ form_validation 3.1.0+6
+ frontend_server_client 3.2.0
+ glob 2.1.2
+ graphs 2.3.1
+ http 1.1.0
+ http_multi_server 3.2.1
+ http_parser 4.0.2
+ interpolation 2.1.2
+ intl 0.18.1
+ io 1.0.4
+ iregexp 0.1.1 (0.1.2 available)
+ js 0.6.7
+ json_annotation 4.8.1
+ json_class 3.0.0+6
+ json_conditional 3.0.0+9
! json_dynamic_widget_codegen 1.0.2+1 from path ../codegen (overridden)
+ json_path 0.6.3 (0.6.6 available)
+ json_schema 5.1.3
+ json_theme 6.3.0
+ json_theme_annotation 1.0.1+1
+ lints 3.0.0
+ logging 1.2.0
+ matcher 0.12.16
+ material_color_utilities 0.5.0 (0.8.0 available)
+ maybe_just_nothing 0.5.3
+ meta 1.9.1 (1.11.0 available)
+ mime 1.0.4
+ package_config 2.1.0
+ path 1.8.3
+ petitparser 5.4.0 (6.0.1 available)
+ pointycastle 3.7.3
+ pool 1.5.1
+ pub_semver 2.1.4
+ pubspec_parse 1.2.3
+ quiver 3.2.1
+ recase 4.1.0
+ rfc_6901 0.1.1 (0.2.0 available)
+ rxdart 0.27.7
+ shelf 1.4.1
+ shelf_web_socket 1.0.4
+ sky_engine 0.0.99 from sdk flutter
+ source_gen 1.4.0
+ source_span 1.10.0
+ sprintf 7.0.0
+ stack_trace 1.11.0 (1.11.1 available)
+ stream_channel 2.1.1 (2.1.2 available)
+ stream_transform 2.1.0
+ string_scanner 1.2.0
+ template_expressions 3.1.4+1
+ term_glyph 1.2.1
+ test_api 0.6.0 (0.6.1 available)
+ timing 1.0.1
+ typed_data 1.3.2
+ uri 1.0.0
+ uuid 4.1.0
+ vector_math 2.1.4
+ watcher 1.1.0
+ web 0.1.4-beta (0.3.0 available)
+ web_socket_channel 2.4.0
+ yaml 3.1.2
+ yaml_writer 1.0.3
+ yaon 1.1.2+5
Changed 94 dependencies!
Resolving dependencies in ./example...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Because every version of json_dynamic_widget from path depends on execution_timer ^1.0.3+7 which depends on flutter_lints ^3.0.0, every version of json_dynamic_widget from path requires flutter_lints ^3.0.0.
So, because example depends on both json_dynamic_widget from path and flutter_lints ^2.0.3, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Try upgrading your constraint on flutter_lints: flutter pub add dev:flutter_lints:^3.0.0

```


dependencies:
  * `execution_timer`: 1.0.3+5 --> 1.0.3+7
  * `json_class`: 3.0.0+5 --> 3.0.0+6
  * `yaon`: 1.1.2+4 --> 1.1.2+5

dev_dependencies:
  * `flutter_lints`: 2.0.3 --> 3.0.0
  * `json_dynamic_widget_codegen`: 1.0.1 --> 1.0.2


Analysis Successful

