### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,15 +30,14 @@ jobs:
       - name: Validate
         uses: peiffer-innovations/actions-flutter-validate@v1
         with:
-          path: annotations
-          
+          path: annotation
+
       - name: Validate
         uses: peiffer-innovations/actions-flutter-validate@v1
         with:
           path: codegen
-          
+
       - name: Validate
         uses: peiffer-innovations/actions-flutter-validate@v1
         with:
           path: json_dynamic_widget
-          

--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.1+1] - November 7, 2023
+
+* Automated dependency updates
+
+
 ## [1.1.1] - November 2nd, 2023
 
 * Update to [flutter_lints](https://pub.dev/packages/flutter_lints) `3.0.0`
@@ -16,4 +21,5 @@
 ## [1.0.0] - August 12th, 2023
 
 * Initial release
+
 

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,24 +1,25 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.1'
+version: '1.1.1+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
+
+dependencies: 
   meta: '^1.9.1'
 
-dev_dependencies:
-  flutter_lints: '^3.0.0'
-  test: '^1.24.7'
+dev_dependencies: 
+  flutter_lints: '^3.0.1'
+  test: '^1.24.9'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,25 +1,24 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.1+1'
+version: '1.1.2'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer: 
-  exclude: 
+analyzer:
+  exclude:
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-
-dependencies: 
+dependencies:
   meta: '^1.9.1'
 
-dev_dependencies: 
+dev_dependencies:
   flutter_lints: '^3.0.1'
   test: '^1.24.9'
 
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.4+1] - November 7, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.4] - November 2nd, 2023
 
 * Update to [flutter_lints](https://pub.dev/packages/flutter_lints) `3.0.0`
@@ -40,4 +45,5 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,34 +1,35 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.4'
+version: '1.0.4+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
+
+dependencies: 
   analyzer: '^6.2.0'
   build: '^2.4.1'
   code_builder: '^4.7.0'
-  dynamic_widget_annotation: '^1.1.0+1'
-  json_class: '^3.0.0+5'
-  json_theme: '^6.3.0'
+  dynamic_widget_annotation: '^1.1.1'
+  json_class: '^3.0.0+8'
+  json_theme: '^6.3.1'
   recase: '^4.1.0'
   source_gen: '^1.4.0'
-  template_expressions: '^3.1.2+3'
+  template_expressions: '^3.1.4+3'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.2+5'
+  yaon: '^1.1.2+6'
 
-dev_dependencies:
-  flutter_lints: '^3.0.0'
-  test: '^1.24.8'
+dev_dependencies: 
+  flutter_lints: '^3.0.1'
+  test: '^1.24.9'
 
-ignore_updates:
+ignore_updates: 
   - 'analyzer'
   - 'archive'
   - 'async'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.4+2] - November 7, 2023
+
+* Automated dependency updates
+
+
 ## [7.0.4+1] - November 2nd, 2023
 
 * Update to [flutter_lints](https://pub.dev/packages/flutter_lints) `3.0.0`
@@ -693,6 +698,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [7.0.4+2] - November 7, 2023
+## [7.0.5] - November 12th, 2023
 
-* Automated dependency updates
+* Dependency updates
 
 
 ## [7.0.4+1] - November 2nd, 2023

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,72 +1,75 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+44'
+version: '1.0.0+45'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
+dependencies: 
   child_builder: '^2.0.1'
   desktop_window: '^0.4.0'
   dotted_border: '^2.1.0'
-  execution_timer: '^1.0.3+5'
-  flutter:
+  execution_timer: '^1.1.0+2'
+  flutter: 
     sdk: 'flutter'
-  flutter_svg: '^2.0.7'
-  json_class: '^3.0.0+5'
-  json_dynamic_widget:
+  flutter_svg: '^2.0.9'
+  json_class: '^3.0.0+8'
+  json_dynamic_widget: 
     path: '../'
-  json_theme: '^6.3.0'
+  json_theme: '^6.3.1'
   logging: '^1.2.0'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+6'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.4.6'
-  flutter_lints: '^3.0.0'
-  flutter_test:
+  flutter_lints: '^3.0.1'
+  flutter_test: 
     sdk: 'flutter'
-  icons_launcher: '^2.1.4'
-  json_dynamic_widget_codegen: '^1.0.3+2'
+  icons_launcher: '^2.1.5'
+  json_dynamic_widget_codegen: '^1.0.4'
   yaml_writer: '^1.0.3'
 
-# dependency_overrides:
-#   json_dynamic_widget_codegen:
-#     path: ../../codegen
-
-icons_launcher:
+icons_launcher: 
   image_path: 'assets-src/icon.png'
-  platforms:
-    android:
+  platforms: 
+    android: 
       enable: true
-    ios:
+    ios: 
       enable: true
-    linux:
+    linux: 
       enable: true
-    macos:
+    macos: 
       enable: true
-    web:
+    web: 
       enable: true
-    windows:
+    windows: 
       enable: true
 
-flutter:
+
+flutter: 
   uses-material-design: true
-  assets:
+  assets: 
     - 'assets/images/'
     - 'assets/pages/'
     - 'assets/secrets/'
     - 'assets/widgets/'
-  fonts:
-    - family: 'lato'
-      fonts:
-        - asset: 'assets/fonts/Lato-Regular.ttf'
+  fonts: 
+    - 
+      family: 'lato'
+      fonts: 
+        - 
+          asset: 'assets/fonts/Lato-Regular.ttf'
 
-    - family: 'metal'
-      fonts:
-        - asset: 'assets/fonts/MetalMania-Regular.ttf'
+    - 
+      family: 'metal'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MetalMania-Regular.ttf'
 
-ignore_updates:
+
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,49 +1,47 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.4+2'
+version: '7.0.5'
 
-environment: 
+environment:
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer: 
-  exclude: 
+analyzer:
+  exclude:
     - 'lib/generated/**'
 
-
-dependencies: 
+dependencies:
   child_builder: '^2.0.1'
   collection: '^1.17.1'
   dynamic_widget_annotation: '^1.1.1'
   execution_timer: '^1.1.0+2'
-  flutter: 
+  flutter:
     sdk: 'flutter'
   form_validation: '^3.1.0+8'
   interpolation: '^2.1.2'
   json_class: '^3.0.0+8'
   json_conditional: '^3.0.0+11'
   json_schema: '^5.1.3'
-  json_theme: '^6.3.1'
+  json_theme: '^6.3.2'
   logging: '^1.2.0'
   meta: '^1.9.1'
   template_expressions: '^3.1.4+3'
-  uuid: '^4.2.0'
+  uuid: '^4.1.0'
   yaml_writer: '^1.0.3'
   yaon: '^1.1.2+6'
 
-dev_dependencies: 
+dev_dependencies:
   build_runner: '^2.4.6'
   flutter_lints: '^3.0.1'
-  flutter_test: 
+  flutter_test:
     sdk: 'flutter'
   json_dynamic_widget_codegen: '^1.0.4'
 
-dependency_overrides: 
-  json_dynamic_widget_codegen: 
+dependency_overrides:
+  json_dynamic_widget_codegen:
     path: '../codegen'
 
-
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'
@@ -66,5 +64,6 @@ ignore_updates:
   - 'term_glyph'
   - 'test_api'
   - 'typed_data'
+  - 'uuid'
   - 'vector_math'
   - 'webdriver'

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,47 +1,49 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.4+1'
+version: '7.0.4+2'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.1'
   collection: '^1.17.1'
-  dynamic_widget_annotation: '^1.1.0'
-  execution_timer: '^1.1.0'
-  flutter:
+  dynamic_widget_annotation: '^1.1.1'
+  execution_timer: '^1.1.0+2'
+  flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.0+5'
+  form_validation: '^3.1.0+8'
   interpolation: '^2.1.2'
-  json_class: '^3.0.0+5'
-  json_conditional: '^3.0.0+7'
+  json_class: '^3.0.0+8'
+  json_conditional: '^3.0.0+11'
   json_schema: '^5.1.3'
-  json_theme: '^6.3.0'
+  json_theme: '^6.3.1'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.2+2'
-  uuid: '^4.1.0'
+  template_expressions: '^3.1.4+3'
+  uuid: '^4.2.0'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.2+4'
+  yaon: '^1.1.2+6'
 
-dev_dependencies:
+dev_dependencies: 
   build_runner: '^2.4.6'
-  flutter_lints: '^3.0.0'
-  flutter_test:
+  flutter_lints: '^3.0.1'
+  flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.3+2'
+  json_dynamic_widget_codegen: '^1.0.4'
 
-dependency_overrides:
-  json_dynamic_widget_codegen:
-    path: ../codegen
+dependency_overrides: 
+  json_dynamic_widget_codegen: 
+    path: '../codegen'
 
-ignore_updates:
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `flutter_lints`: 3.0.0 --> 3.0.1
  * `test`: 1.24.7 --> 1.24.9


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.0+1 --> 1.1.1
  * `json_class`: 3.0.0+5 --> 3.0.0+8
  * `json_theme`: 6.3.0 --> 6.3.1
  * `template_expressions`: 3.1.2+3 --> 3.1.4+3
  * `yaon`: 1.1.2+5 --> 1.1.2+6

dev_dependencies:
  * `flutter_lints`: 3.0.0 --> 3.0.1
  * `test`: 1.24.8 --> 1.24.9


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.0 --> 1.1.1
  * `execution_timer`: 1.1.0 --> 1.1.0+2
  * `form_validation`: 3.1.0+5 --> 3.1.0+8
  * `json_class`: 3.0.0+5 --> 3.0.0+8
  * `json_conditional`: 3.0.0+7 --> 3.0.0+11
  * `json_theme`: 6.3.0 --> 6.3.1
  * `template_expressions`: 3.1.2+2 --> 3.1.4+3
  * `uuid`: 4.1.0 --> 4.2.0
  * `yaon`: 1.1.2+4 --> 1.1.2+6

dev_dependencies:
  * `flutter_lints`: 3.0.0 --> 3.0.1
  * `json_dynamic_widget_codegen`: 1.0.3+2 --> 1.0.4


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Note: meta is pinned to version 1.9.1 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on meta 1.9.1 and uuid >=4.2.0 depends on meta ^1.11.0, flutter_test from sdk is incompatible with uuid >=4.2.0.
So, because json_dynamic_widget depends on both uuid ^4.2.0 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on uuid: flutter pub add uuid:^4.1.0

```


dependencies:
  * `execution_timer`: 1.0.3+5 --> 1.1.0+2
  * `flutter_svg`: 2.0.7 --> 2.0.9
  * `json_class`: 3.0.0+5 --> 3.0.0+8
  * `json_theme`: 6.3.0 --> 6.3.1
  * `yaon`: 1.1.2+4 --> 1.1.2+6

dev_dependencies:
  * `flutter_lints`: 3.0.0 --> 3.0.1
  * `icons_launcher`: 2.1.4 --> 2.1.5
  * `json_dynamic_widget_codegen`: 1.0.3+2 --> 1.0.4


Error!!!
```
Resolving dependencies...


Note: meta is pinned to version 1.9.1 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter from sdk depends on meta 1.9.1 and uuid >=4.2.0 depends on meta ^1.11.0, flutter from sdk is incompatible with uuid >=4.2.0.
And because every version of json_dynamic_widget from path depends on uuid ^4.2.0, flutter from sdk is incompatible with json_dynamic_widget from path.
So, because example depends on both flutter from sdk and json_dynamic_widget from path, version solving failed.

```

