### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.4+3] - November 21, 2023
+
+* Automated dependency updates
+
+
 ## [1.0.4+2] - November 14, 2023
 
 * Automated dependency updates
@@ -50,6 +55,7 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 
 
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.4+2'
+version: '1.0.4+3'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -15,15 +15,15 @@ analyzer:
 dependencies: 
   analyzer: '^6.2.0'
   build: '^2.4.1'
-  code_builder: '^4.7.0'
+  code_builder: '^4.8.0'
   dynamic_widget_annotation: '^1.1.2'
   json_class: '^3.0.0+8'
-  json_theme: '^6.3.2'
+  json_theme: '^6.4.0'
   recase: '^4.1.0'
   source_gen: '^1.4.0'
-  template_expressions: '^3.1.4+4'
+  template_expressions: '^3.1.5'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.3'
+  yaon: '^1.1.4'
 
 dev_dependencies: 
   flutter_lints: '^3.0.1'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.5+2] - November 21, 2023
+
+* Automated dependency updates
+
+
 ## [7.0.5+1] - November 14, 2023
 
 * Automated dependency updates
@@ -703,6 +708,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,13 +1,13 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+46'
+version: '1.0.0+47'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies: 
-  child_builder: '^2.0.1'
+  child_builder: '^2.0.2'
   desktop_window: '^0.4.0'
   dotted_border: '^2.1.0'
   execution_timer: '^1.1.0+2'
@@ -17,9 +17,9 @@ dependencies:
   json_class: '^3.0.0+8'
   json_dynamic_widget: 
     path: '../'
-  json_theme: '^6.3.2'
+  json_theme: '^6.4.0'
   logging: '^1.2.0'
-  yaon: '^1.1.3'
+  yaon: '^1.1.4'
 
 dev_dependencies: 
   build_runner: '^2.4.6'
@@ -27,7 +27,7 @@ dev_dependencies:
   flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.5'
-  json_dynamic_widget_codegen: '^1.0.4+1'
+  json_dynamic_widget_codegen: '^1.0.4+2'
   yaml_writer: '^1.0.3'
 
 icons_launcher: 

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.5+1'
+version: '7.0.5+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -12,31 +12,31 @@ analyzer:
 
 
 dependencies: 
-  child_builder: '^2.0.1'
+  child_builder: '^2.0.2'
   collection: '^1.17.1'
   dynamic_widget_annotation: '^1.1.2'
   execution_timer: '^1.1.0+2'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.0+8'
+  form_validation: '^3.1.1'
   interpolation: '^2.1.2'
   json_class: '^3.0.0+8'
-  json_conditional: '^3.0.0+12'
+  json_conditional: '^3.0.1'
   json_schema: '^5.1.3'
-  json_theme: '^6.3.2'
+  json_theme: '^6.4.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.4+4'
+  template_expressions: '^3.1.5'
   uuid: '^4.1.0'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.3'
+  yaon: '^1.1.4'
 
 dev_dependencies: 
   build_runner: '^2.4.6'
   flutter_lints: '^3.0.1'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.4+1'
+  json_dynamic_widget_codegen: '^1.0.4+2'
 
 dependency_overrides: 
   json_dynamic_widget_codegen: 


### PR DESCRIPTION
PR created automatically



dependencies:
  * `code_builder`: 4.7.0 --> 4.8.0
  * `json_theme`: 6.3.2 --> 6.4.0
  * `template_expressions`: 3.1.4+4 --> 3.1.5
  * `yaon`: 1.1.3 --> 1.1.4


Analysis Successful


dependencies:
  * `child_builder`: 2.0.1 --> 2.0.2
  * `form_validation`: 3.1.0+8 --> 3.1.1
  * `json_conditional`: 3.0.0+12 --> 3.0.1
  * `json_theme`: 6.3.2 --> 6.4.0
  * `template_expressions`: 3.1.4+4 --> 3.1.5
  * `yaon`: 1.1.3 --> 1.1.4

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.4+1 --> 1.0.4+2


Analysis Successful


dependencies:
  * `child_builder`: 2.0.1 --> 2.0.2
  * `json_theme`: 6.3.2 --> 6.4.0
  * `yaon`: 1.1.3 --> 1.1.4

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.4+1 --> 1.0.4+2


Analysis Successful

