### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2+2] - January 16, 2024
+
+* Automated dependency updates
+
+
 ## [1.1.2+1] - December 19, 2023
 
 * Automated dependency updates
@@ -26,6 +31,7 @@
 ## [1.0.0] - August 12th, 2023
 
 * Initial release
+
 
 
 

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.2+1'
+version: '1.1.2+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies: 
   flutter_lints: '^3.0.1'
-  test: '^1.25.0'
+  test: '^1.25.1'
 
 ignore_updates: 
   - 'archive'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.5+2] - January 16, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.5+1] - January 9, 2024
 
 * Automated dependency updates
@@ -74,6 +79,7 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 
 
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.5+1'
+version: '1.0.5+2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -17,17 +17,17 @@ dependencies:
   build: '^2.4.1'
   code_builder: '^4.10.0'
   dynamic_widget_annotation: '^1.1.2+1'
-  json_class: '^3.0.0+10'
+  json_class: '^3.0.0+11'
   json_theme: '^6.4.0'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
-  template_expressions: '^3.1.5+2'
+  template_expressions: '^3.1.5+3'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.4+1'
+  yaon: '^1.1.4+2'
 
 dev_dependencies: 
   flutter_lints: '^3.0.1'
-  test: '^1.25.0'
+  test: '^1.25.1'
 
 ignore_updates: 
   - 'analyzer'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.6+5] - January 16, 2024
+
+* Automated dependency updates
+
+
 ## [7.0.6+4] - December 27th, 2023
 
 * Codegen dependency updates
@@ -729,6 +734,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+50'
+version: '1.0.0+51'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -10,24 +10,24 @@ dependencies:
   child_builder: '^2.0.2'
   desktop_window: '^0.4.0'
   dotted_border: '^2.1.0'
-  execution_timer: '^1.1.0+3'
+  execution_timer: '^1.1.0+4'
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.9'
-  json_class: '^3.0.0+10'
+  json_class: '^3.0.0+11'
   json_dynamic_widget: 
     path: '../'
   json_theme: '^6.4.0'
   logging: '^1.2.0'
-  yaon: '^1.1.4+1'
+  yaon: '^1.1.4+2'
 
 dev_dependencies: 
-  build_runner: '^2.4.7'
+  build_runner: '^2.4.8'
   flutter_lints: '^3.0.1'
   flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.7'
-  json_dynamic_widget_codegen: '^1.0.5'
+  json_dynamic_widget_codegen: '^1.0.5+1'
   yaml_writer: '^1.0.3'
 
 dependency_overrides: 

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,47 +1,49 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.6+4'
+version: '7.0.6+5'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
 
-dependencies:
+
+dependencies: 
   child_builder: '^2.0.2'
   collection: '^1.17.1'
   dynamic_widget_annotation: '^1.1.2+1'
-  execution_timer: '^1.1.0+3'
-  flutter:
+  execution_timer: '^1.1.0+4'
+  flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.1+2'
+  form_validation: '^3.1.1+3'
   interpolation: '^2.1.2'
-  json_class: '^3.0.0+10'
-  json_conditional: '^3.0.1+2'
+  json_class: '^3.0.0+11'
+  json_conditional: '^3.0.1+3'
   json_schema: '^5.1.3'
   json_theme: '^6.4.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.5+2'
+  template_expressions: '^3.1.5+3'
   uuid: '^4.1.0'
   yaml_writer: '^1.0.3'
-  yaon: '^1.1.4+1'
+  yaon: '^1.1.4+2'
 
-dev_dependencies:
-  build_runner: '^2.4.7'
+dev_dependencies: 
+  build_runner: '^2.4.8'
   flutter_lints: '^3.0.1'
-  flutter_test:
+  flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.5'
+  json_dynamic_widget_codegen: '^1.0.5+1'
 
-dependency_overrides:
-  json_dynamic_widget_codegen:
+dependency_overrides: 
+  json_dynamic_widget_codegen: 
     path: '../codegen'
 
-ignore_updates:
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.25.0 --> 1.25.1


Analysis Successful


dependencies:
  * `json_class`: 3.0.0+10 --> 3.0.0+11
  * `template_expressions`: 3.1.5+2 --> 3.1.5+3
  * `yaon`: 1.1.4+1 --> 1.1.4+2

dev_dependencies:
  * `test`: 1.25.0 --> 1.25.1


Analysis Successful


dependencies:
  * `execution_timer`: 1.1.0+3 --> 1.1.0+4
  * `form_validation`: 3.1.1+2 --> 3.1.1+3
  * `json_class`: 3.0.0+10 --> 3.0.0+11
  * `json_conditional`: 3.0.1+2 --> 3.0.1+3
  * `template_expressions`: 3.1.5+2 --> 3.1.5+3
  * `yaon`: 1.1.4+1 --> 1.1.4+2

dev_dependencies:
  * `build_runner`: 2.4.7 --> 2.4.8
  * `json_dynamic_widget_codegen`: 1.0.5 --> 1.0.5+1


Analysis Successful


dependencies:
  * `execution_timer`: 1.1.0+3 --> 1.1.0+4
  * `json_class`: 3.0.0+10 --> 3.0.0+11
  * `yaon`: 1.1.4+1 --> 1.1.4+2

dev_dependencies:
  * `build_runner`: 2.4.7 --> 2.4.8
  * `json_dynamic_widget_codegen`: 1.0.5 --> 1.0.5+1


Analysis Successful

