### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2+3] - February 20, 2024
+
+* Automated dependency updates
+
+
 ## [1.1.2+2] - January 16, 2024
 
 * Automated dependency updates
@@ -31,6 +36,7 @@
 ## [1.0.0] - August 12th, 2023
 
 * Initial release
+
 
 
 

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.2+2'
+version: '1.1.2+3'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -11,13 +11,12 @@ analyzer:
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-
 dependencies: 
   meta: '^1.9.1'
 
 dev_dependencies: 
   flutter_lints: '^3.0.1'
-  test: '^1.25.1'
+  test: '^1.25.2'
 
 ignore_updates: 
   - 'archive'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.5+3] - February 20, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.5+2] - January 16, 2024
 
 * Automated dependency updates
@@ -79,6 +84,7 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 
 
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.5+2'
+version: '1.0.5+3'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -11,23 +11,22 @@ analyzer:
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-
 dependencies: 
   analyzer: '^6.2.0'
   build: '^2.4.1'
   code_builder: '^4.10.0'
-  dynamic_widget_annotation: '^1.1.2+1'
-  json_class: '^3.0.0+11'
+  dynamic_widget_annotation: '^1.1.2+2'
+  json_class: '^3.0.0+12'
   json_theme: '^6.4.0'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
-  template_expressions: '^3.1.5+3'
-  yaml_writer: '^1.0.3'
-  yaon: '^1.1.4+2'
+  template_expressions: '^3.1.5+5'
+  yaml_writer: '^2.0.0'
+  yaon: '^1.1.4+4'
 
 dev_dependencies: 
   flutter_lints: '^3.0.1'
-  test: '^1.25.1'
+  test: '^1.25.2'
 
 ignore_updates: 
   - 'analyzer'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.0.6+6] - February 20, 2024
+
+* Automated dependency updates
+
+
 ## [7.0.6+5] - January 16, 2024
 
 * Automated dependency updates
@@ -734,6 +739,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+51'
+version: '1.0.0+52'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -10,16 +10,16 @@ dependencies:
   child_builder: '^2.0.2'
   desktop_window: '^0.4.0'
   dotted_border: '^2.1.0'
-  execution_timer: '^1.1.0+4'
+  execution_timer: '^1.1.0+5'
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.9'
-  json_class: '^3.0.0+11'
+  json_class: '^3.0.0+12'
   json_dynamic_widget: 
     path: '../'
   json_theme: '^6.4.0'
   logging: '^1.2.0'
-  yaon: '^1.1.4+2'
+  yaon: '^1.1.4+4'
 
 dev_dependencies: 
   build_runner: '^2.4.8'
@@ -27,13 +27,12 @@ dev_dependencies:
   flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.7'
-  json_dynamic_widget_codegen: '^1.0.5+1'
-  yaml_writer: '^1.0.3'
+  json_dynamic_widget_codegen: '^1.0.5+2'
+  yaml_writer: '^2.0.0'
 
 dependency_overrides: 
   json_dynamic_widget_codegen: 
     path: '../../codegen'
-
 
 icons_launcher: 
   image_path: 'assets-src/icon.png'
@@ -51,7 +50,6 @@ icons_launcher:
     windows: 
       enable: true
 
-
 flutter: 
   uses-material-design: true
   assets: 
@@ -60,19 +58,12 @@ flutter:
     - 'assets/secrets/'
     - 'assets/widgets/'
   fonts: 
-    - 
-      family: 'lato'
+    - family: 'lato'
       fonts: 
-        - 
-          asset: 'assets/fonts/Lato-Regular.ttf'
-
-    - 
-      family: 'metal'
+        - asset: 'assets/fonts/Lato-Regular.ttf'
+    - family: 'metal'
       fonts: 
-        - 
-          asset: 'assets/fonts/MetalMania-Regular.ttf'
-
-
+        - asset: 'assets/fonts/MetalMania-Regular.ttf'
 
 ignore_updates: 
   - 'archive'

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.0.6+5'
+version: '7.0.6+6'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -10,38 +10,36 @@ analyzer:
   exclude: 
     - 'lib/generated/**'
 
-
 dependencies: 
   child_builder: '^2.0.2'
   collection: '^1.17.1'
-  dynamic_widget_annotation: '^1.1.2+1'
-  execution_timer: '^1.1.0+4'
+  dynamic_widget_annotation: '^1.1.2+2'
+  execution_timer: '^1.1.0+5'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.1+3'
+  form_validation: '^3.1.1+4'
   interpolation: '^2.1.2'
-  json_class: '^3.0.0+11'
-  json_conditional: '^3.0.1+3'
+  json_class: '^3.0.0+12'
+  json_conditional: '^3.0.1+6'
   json_schema: '^5.1.3'
   json_theme: '^6.4.0'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.1.5+3'
+  template_expressions: '^3.1.5+5'
   uuid: '^4.1.0'
-  yaml_writer: '^1.0.3'
-  yaon: '^1.1.4+2'
+  yaml_writer: '^2.0.0'
+  yaon: '^1.1.4+4'
 
 dev_dependencies: 
   build_runner: '^2.4.8'
   flutter_lints: '^3.0.1'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.5+1'
+  json_dynamic_widget_codegen: '^1.0.5+2'
 
 dependency_overrides: 
   json_dynamic_widget_codegen: 
     path: '../codegen'
-
 
 ignore_updates: 
   - 'archive'


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.25.1 --> 1.25.2


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.2+1 --> 1.1.2+2
  * `json_class`: 3.0.0+11 --> 3.0.0+12
  * `template_expressions`: 3.1.5+3 --> 3.1.5+5
  * `yaml_writer`: 1.0.3 --> 2.0.0
  * `yaon`: 1.1.4+2 --> 1.1.4+4

dev_dependencies:
  * `test`: 1.25.1 --> 1.25.2


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.2+1 --> 1.1.2+2
  * `execution_timer`: 1.1.0+4 --> 1.1.0+5
  * `form_validation`: 3.1.1+3 --> 3.1.1+4
  * `json_class`: 3.0.0+11 --> 3.0.0+12
  * `json_conditional`: 3.0.1+3 --> 3.0.1+6
  * `template_expressions`: 3.1.5+3 --> 3.1.5+5
  * `yaml_writer`: 1.0.3 --> 2.0.0
  * `yaon`: 1.1.4+2 --> 1.1.4+4

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.5+1 --> 1.0.5+2


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
+ _fe_analyzer_shared 67.0.0
+ analyzer 6.4.1
+ args 2.4.2
+ asn1lib 1.5.2
+ async 2.11.0
+ boolean_selector 2.1.1
+ build 2.4.1
+ build_config 1.1.1
+ build_daemon 4.0.1
+ build_resolvers 2.4.2
+ build_runner 2.4.8
+ build_runner_core 7.3.0
+ built_collection 5.1.1
+ built_value 8.9.1
+ characters 1.3.0
+ checked_yaml 2.0.3
+ child_builder 2.0.2
+ clock 1.1.1
+ code_builder 4.10.0
+ collection 1.18.0
+ convert 3.1.1
+ crypto 3.0.3
+ dart_style 2.3.4
+ dynamic_widget_annotation 1.1.2+2
+ encrypt 5.0.3
+ execution_timer 1.1.0+5
+ fake_async 1.3.1
+ file 7.0.0
+ fixnum 1.1.0
+ flutter 0.0.0 from sdk flutter
+ flutter_lints 3.0.1
+ flutter_test 0.0.0 from sdk flutter
+ form_validation 3.1.1+4
+ frontend_server_client 3.2.0
+ glob 2.1.2
+ graphs 2.3.1
+ http 1.2.1
+ http_multi_server 3.2.1
+ http_parser 4.0.2
+ interpolation 2.1.2
+ intl 0.19.0
+ io 1.0.4
+ iregexp 0.1.2
+ js 0.7.1
+ json_annotation 4.8.1
+ json_class 3.0.0+12
+ json_conditional 3.0.1+6
! json_dynamic_widget_codegen 1.0.5+3 from path ../codegen (overridden)
+ json_path 0.6.6 (0.7.0 available)
+ json_schema 5.1.3
+ json_theme 6.4.0
+ json_theme_annotation 1.0.3+3
+ leak_tracker 10.0.0 (10.0.4 available)
+ leak_tracker_flutter_testing 2.0.1 (3.0.3 available)
+ leak_tracker_testing 2.0.1 (3.0.1 available)
+ lints 3.0.0
+ logging 1.2.0
+ matcher 0.12.16+1
+ material_color_utilities 0.8.0
+ maybe_just_nothing 0.5.3
+ meta 1.11.0 (1.12.0 available)
+ mime 1.0.5
+ package_config 2.1.0
+ path 1.9.0
+ petitparser 6.0.2
+ pointycastle 3.7.4
+ pool 1.5.1
+ pub_semver 2.1.4
+ pubspec_parse 1.2.3
+ quiver 3.2.1
+ recase 4.1.0
+ rfc_6901 0.2.0
+ rxdart 0.27.7
+ shelf 1.4.1
+ shelf_web_socket 1.0.4
+ sky_engine 0.0.99 from sdk flutter
+ source_gen 1.5.0
+ source_span 1.10.0
+ sprintf 7.0.0
+ stack_trace 1.11.1
+ stream_channel 2.1.2
+ stream_transform 2.1.0
+ string_scanner 1.2.0
+ template_expressions 3.1.5+5
+ term_glyph 1.2.1
+ test_api 0.6.1 (0.7.0 available)
+ timing 1.0.1
+ typed_data 1.3.2
+ uri 1.0.0
+ uuid 4.3.3
+ vector_math 2.1.4
+ vm_service 13.0.0 (14.0.0 available)
+ watcher 1.1.0
+ web 0.5.0
+ web_socket_channel 2.4.4
+ yaml 3.1.2
+ yaml_writer 2.0.0
+ yaon 1.1.4+4
Changed 97 dependencies!
7 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Resolving dependencies in ./example...


Because every version of json_dynamic_widget_codegen from path depends on yaml_writer ^2.0.0 and example depends on yaml_writer ^1.0.3, json_dynamic_widget_codegen from path is forbidden.
So, because example depends on json_dynamic_widget_codegen from path, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Try upgrading your constraint on yaml_writer: flutter pub add dev:yaml_writer:^2.0.0

```


dependencies:
  * `execution_timer`: 1.1.0+4 --> 1.1.0+5
  * `json_class`: 3.0.0+11 --> 3.0.0+12
  * `yaon`: 1.1.4+2 --> 1.1.4+4

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.5+1 --> 1.0.5+2
  * `yaml_writer`: 1.0.3 --> 2.0.0


Analysis Successful

