### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2+5] - April 23, 2024
+
+* Automated dependency updates
+
+
 ## [1.1.2+4] - April 2, 2024
 
 * Automated dependency updates
@@ -41,6 +46,7 @@
 ## [1.0.0] - August 12th, 2023
 
 * Initial release
+
 
 
 

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.2+4'
+version: '1.1.2+5'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -16,7 +16,7 @@ dependencies:
 
 dev_dependencies: 
   flutter_lints: '^3.0.2'
-  test: '^1.25.2'
+  test: '^1.25.4'
 
 ignore_updates: 
   - 'archive'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.5+9] - April 23, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.5+8] - April 9, 2024
 
 * Automated dependency updates
@@ -109,6 +114,7 @@
 
 * Initial release
     * Documentation coming in an upcoming 1.0.0 release
+
 
 
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.5+8'
+version: '1.0.5+9'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -17,16 +17,16 @@ dependencies:
   code_builder: '^4.10.0'
   dynamic_widget_annotation: '^1.1.2+4'
   json_class: '^3.0.0+13'
-  json_theme: '^6.4.1+1'
+  json_theme: '^6.4.1+3'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
-  template_expressions: '^3.2.0+3'
+  template_expressions: '^3.2.0+5'
   yaml_writer: '^2.0.0'
-  yaon: '^1.1.4+6'
+  yaon: '^1.1.4+8'
 
 dev_dependencies: 
   flutter_lints: '^3.0.2'
-  test: '^1.25.2'
+  test: '^1.25.4'
 
 ignore_updates: 
   - 'analyzer'

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.1.0+8] - April 23, 2024
+
+* Automated dependency updates
+
+
 ## [7.1.0+7] - April 9, 2024
 
 * Automated dependency updates
@@ -775,6 +780,7 @@ This is a huge release with several breaking changes.  It brings in the ability 
 ## [0.9.9] - July 18th, 2020
 
 * Initial release
+
 
 
 

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+59'
+version: '1.0.0+60'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -17,9 +17,9 @@ dependencies:
   json_class: '^3.0.0+13'
   json_dynamic_widget: 
     path: '../'
-  json_theme: '^6.4.1+1'
+  json_theme: '^6.4.1+3'
   logging: '^1.2.0'
-  yaon: '^1.1.4+6'
+  yaon: '^1.1.4+8'
 
 dev_dependencies: 
   build_runner: '^2.4.9'
@@ -27,7 +27,7 @@ dev_dependencies:
   flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.7'
-  json_dynamic_widget_codegen: '^1.0.5+7'
+  json_dynamic_widget_codegen: '^1.0.5+8'
   yaml_writer: '^2.0.0'
 
 dependency_overrides: 

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.1.0+7'
+version: '7.1.0+8'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -20,22 +20,22 @@ dependencies:
   form_validation: '^3.1.1+5'
   interpolation: '^2.1.2'
   json_class: '^3.0.0+13'
-  json_conditional: '^3.0.1+8'
+  json_conditional: '^3.0.1+10'
   json_schema: '^5.1.7'
-  json_theme: '^6.4.1+1'
+  json_theme: '^6.4.1+3'
   logging: '^1.2.0'
   meta: '^1.9.1'
-  template_expressions: '^3.2.0+3'
+  template_expressions: '^3.2.0+5'
   uuid: '^4.1.0'
   yaml_writer: '^2.0.0'
-  yaon: '^1.1.4+6'
+  yaon: '^1.1.4+8'
 
 dev_dependencies: 
   build_runner: '^2.4.9'
   flutter_lints: '^3.0.2'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.5+7'
+  json_dynamic_widget_codegen: '^1.0.5+8'
 
 dependency_overrides: 
   json_dynamic_widget_codegen: 


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.25.2 --> 1.25.4


Analysis Successful


dependencies:
  * `json_theme`: 6.4.1+1 --> 6.4.1+3
  * `template_expressions`: 3.2.0+3 --> 3.2.0+5
  * `yaon`: 1.1.4+6 --> 1.1.4+8

dev_dependencies:
  * `test`: 1.25.2 --> 1.25.4


Error!!!
```
Resolving dependencies...


Note: meta is pinned to version 1.11.0 by flutter from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because test >=1.25.3 depends on test_api 0.7.1 which depends on meta ^1.14.0, test >=1.25.3 requires meta ^1.14.0.
And because json_theme >=2.0.0 depends on flutter from sdk which depends on meta 1.11.0, test >=1.25.3 is incompatible with json_theme >=2.0.0.
So, because json_dynamic_widget_codegen depends on both json_theme ^6.4.1+3 and test ^1.25.4, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on test: dart pub add dev:test:^1.25.2

```


dependencies:
  * `json_conditional`: 3.0.1+8 --> 3.0.1+10
  * `json_theme`: 6.4.1+1 --> 6.4.1+3
  * `template_expressions`: 3.2.0+3 --> 3.2.0+5
  * `yaon`: 1.1.4+6 --> 1.1.4+8

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.5+7 --> 1.0.5+8


Analysis Successful


dependencies:
  * `json_theme`: 6.4.1+1 --> 6.4.1+3
  * `yaon`: 1.1.4+6 --> 1.1.4+8

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.5+7 --> 1.0.5+8


Analysis Successful

