### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2+6] - June 11, 2024
+
+* Automated dependency updates
+
+
 ## [1.1.2+5] - June 4, 2024
 
 * Automated dependency updates

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.2+5'
+version: '1.1.2+6'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -16,7 +16,7 @@ dependencies:
 
 dev_dependencies: 
   flutter_lints: '^4.0.0'
-  test: '^1.25.6'
+  test: '^1.25.7'
 
 permittedLicenses: 
   - 'Apache-2.0'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.6+3] - June 11, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.6+2] - June 4, 2024
 
 * Automated dependency updates

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.6+2'
+version: '1.0.6+3'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -15,12 +15,12 @@ dependencies:
   analyzer: '>=6.2.0 <6.5.0'
   build: '^2.4.1'
   code_builder: '^4.10.0'
-  dynamic_widget_annotation: '^1.1.2+4'
-  json_class: '^3.0.0+14'
+  dynamic_widget_annotation: '^1.1.2+5'
+  json_class: '^3.0.0+15'
   json_theme: '^6.5.0+1'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
-  template_expressions: '^3.2.0+8'
+  template_expressions: '^3.2.0+9'
   yaml_writer: '^2.0.0'
   yaon: '^1.1.4+10'
 

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.2.0+4] - June 11, 2024
+
+* Automated dependency updates
+
+
 ## [7.2.0+3] - June 4, 2024
 
 * Automated dependency updates

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+62'
+version: '1.0.0+63'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -14,7 +14,7 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   flutter_svg: '^2.0.10+1'
-  json_class: '^3.0.0+14'
+  json_class: '^3.0.0+15'
   json_dynamic_widget: 
     path: '../'
   json_theme: '^6.5.0+1'
@@ -22,12 +22,12 @@ dependencies:
   yaon: '^1.1.4+10'
 
 dev_dependencies: 
-  build_runner: '^2.4.10'
+  build_runner: '^2.4.11'
   flutter_lints: '^4.0.0'
   flutter_test: 
     sdk: 'flutter'
   icons_launcher: '^2.1.7'
-  json_dynamic_widget_codegen: '^1.0.6+1'
+  json_dynamic_widget_codegen: '^1.0.6+2'
   yaml_writer: '^2.0.0'
 
 dependency_overrides: 

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.2.0+3'
+version: '7.2.0+4'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -13,29 +13,29 @@ analyzer:
 dependencies: 
   child_builder: '^2.0.2'
   collection: '^1.17.1'
-  dynamic_widget_annotation: '^1.1.2+4'
+  dynamic_widget_annotation: '^1.1.2+5'
   execution_timer: '^1.1.0+6'
   flutter: 
     sdk: 'flutter'
-  form_validation: '^3.1.1+5'
+  form_validation: '^3.1.1+6'
   interpolation: '^2.1.2'
-  json_class: '^3.0.0+14'
-  json_conditional: '^3.0.1+13'
+  json_class: '^3.0.0+15'
+  json_conditional: '^3.0.1+14'
   json_schema: '^5.1.7'
   json_theme: '^6.5.0+1'
   logging: '^1.2.0'
   meta: '^1.12.0'
-  template_expressions: '^3.2.0+8'
+  template_expressions: '^3.2.0+9'
   uuid: '^4.1.0'
   yaml_writer: '^2.0.0'
   yaon: '^1.1.4+10'
 
 dev_dependencies: 
-  build_runner: '^2.4.10'
+  build_runner: '^2.4.11'
   flutter_lints: '^4.0.0'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.6+1'
+  json_dynamic_widget_codegen: '^1.0.6+2'
 
 dependency_overrides: 
   json_dynamic_widget_codegen: 


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.25.6 --> 1.25.7


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.2+4 --> 1.1.2+5
  * `json_class`: 3.0.0+14 --> 3.0.0+15
  * `template_expressions`: 3.2.0+8 --> 3.2.0+9


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.2+4 --> 1.1.2+5
  * `form_validation`: 3.1.1+5 --> 3.1.1+6
  * `json_class`: 3.0.0+14 --> 3.0.0+15
  * `json_conditional`: 3.0.1+13 --> 3.0.1+14
  * `template_expressions`: 3.2.0+8 --> 3.2.0+9

dev_dependencies:
  * `build_runner`: 2.4.10 --> 2.4.11
  * `json_dynamic_widget_codegen`: 1.0.6+1 --> 1.0.6+2


Analysis Successful


dependencies:
  * `json_class`: 3.0.0+14 --> 3.0.0+15

dev_dependencies:
  * `build_runner`: 2.4.10 --> 2.4.11
  * `json_dynamic_widget_codegen`: 1.0.6+1 --> 1.0.6+2


Analysis Successful

