### PR TITLE
Feature: add support for mixins in codegen

### DIFF
--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.6+4'
+version: '1.0.6+5'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'

--- a/json_dynamic_widget/README.md
+++ b/json_dynamic_widget/README.md
@@ -223,6 +223,35 @@ See the [Annotations](https://github.com/peiffer-innovations/json_dynamic_widget
 
 ---
 
+### Widget composition
+
+To share the same arguments/annotations between multiple builders you can create mixins with the values you need.
+
+In the following example, `_ColumnBuilder` and `_RowBuilder` shares the same properties (encode/decode/schema) of `children` when genreated.
+
+```dart
+mixin ChildrenArguments {
+  @JsonArgDecoder('children')
+  List<Widget> _decodeChildren({required value}) { ... };
+
+  @JsonArgEncoder('children')
+  static String _encodeChildren(List<Widget> value) { ... };
+
+  @JsonArgSchema('children')
+  static Map<String, dynamic> _childrenSchema() => { ... };
+}
+
+
+@jsonWidget
+abstract class _ColumnBuilder extends JsonWidgetBuilder with ChildrenArguments { ... }
+
+@jsonWidget
+abstract class _RowBuilder extends JsonWidgetBuilder with ChildrenArguments { ... }
+
+```
+
+--- 
+
 ### Migration CLI
 
 This version comes with a script that can migrate existing JSON / YAML files from v6 to v7 automatically.  To run the script, first add the package as a dependency:

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.2.1'
+version: '7.2.2'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -35,7 +35,7 @@ dev_dependencies:
   flutter_lints: '^4.0.0'
   flutter_test: 
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.6+4'
+  json_dynamic_widget_codegen: '^1.0.6+5'
 
 dependency_overrides: 
   json_dynamic_widget_codegen: 


### PR DESCRIPTION
## Description

This feature allow the usage of dart Mixins to share and compose Widget parameters between builders in the project. It is useful when multiple widgets shares the same parameters or even better structure the codebase.

Usage example:

```dart
mixin PropertyABuilder {
  @JsonArgSchema('propertyA')
  static Map<String, dynamic> _propertyASchema() => PropertyASchema.schema;

  @JsonArgEncoder('propertyA')
  static String _encodePropertyA(PropertyA propertyA) =>  PropertyA.values.encode(propertyA);

  @JsonArgDecoder('propertyA')
  PropertyA _decodePropertyA({required String value}) =>  PropertyA.values.decode(value);
}

mixin PropertyBBuilder {
  @JsonArgSchema('propertyB')
  static Map<String, dynamic> _propertyBSchema() => PropertyBSchema.schema;

  @JsonArgEncoder('propertyB')
  static String _encodePropertyB(PropertyB propertyB) =>  PropertyB.values.encode(propertyB);

  @JsonArgDecoder('propertyB')
  PropertyB _decodePropertyB({required String value}) =>  PropertyB.values.decode(value);
}


abstract class MyWidgetBuilder with PropertyABuilder, PropertyBBuilder {
  @override
  MyWidgetBuilder buildCustom({
    ChildWidgetBuilder? childBuilder,
    required BuildContext context,
    required JsonWidgetData data,
    Key? key,
  });
}

```


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
