### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/annotation/CHANGELOG.md
+++ b/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2+10] - December 3, 2024
+
+* Automated dependency updates
+
+
 ## [1.1.2+9] - November 30, 2024
 
 * Automated dependency updates

--- a/annotation/pubspec.yaml
+++ b/annotation/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'dynamic_widget_annotation'
 description: 'Annotations for the json_dynamic_widget library.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/annotation'
-version: '1.1.2+9'
+version: '1.1.2+10'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -16,7 +16,7 @@ dependencies:
 
 dev_dependencies:
   flutter_lints: '^5.0.0'
-  test: '^1.25.9'
+  test: '^1.25.10'
 
 permittedLicenses:
   - 'Apache-2.0'

--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.6+17] - December 3, 2024
+
+* Automated dependency updates
+
+
 ## [1.0.6+16] - November 30, 2024
 
 * Automated dependency updates

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '1.0.6+16'
+version: '1.0.6+17'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -15,12 +15,12 @@ dependencies:
   analyzer: '>=6.2.0 <6.5.0'
   build: '^2.4.1'
   code_builder: '^4.10.1'
-  dynamic_widget_annotation: '^1.1.2+8'
+  dynamic_widget_annotation: '^1.1.2+9'
   json_class: '^3.0.1'
   json_theme: '^6.5.4'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
-  template_expressions: '^3.3.1'
+  template_expressions: '^3.3.1+1'
   yaml_writer: '^2.0.1'
   yaon: '^1.1.4+10'
 

--- a/json_dynamic_widget/CHANGELOG.md
+++ b/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [7.3.1+12] - December 3, 2024
+
+* Automated dependency updates
+
+
 ## [7.3.1+11] - November 30, 2024
 
 * Automated dependency updates

--- a/json_dynamic_widget/example/pubspec.yaml
+++ b/json_dynamic_widget/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example app for the JsonDynamicWidget library'
 publish_to: 'none'
-version: '1.0.0+79'
+version: '1.0.0+80'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -10,7 +10,7 @@ dependencies:
   child_builder: '^2.0.2'
   desktop_window: '^0.4.2'
   dotted_border: '^2.1.0'
-  execution_timer: '^1.1.0+8'
+  execution_timer: '^1.1.0+10'
   flutter:
     sdk: 'flutter'
   flutter_svg: '^2.0.16'
@@ -27,7 +27,7 @@ dev_dependencies:
   flutter_test:
     sdk: 'flutter'
   icons_launcher: '^3.0.0'
-  json_dynamic_widget_codegen: '^1.0.6+15'
+  json_dynamic_widget_codegen: '^1.0.6+16'
   yaml_writer: '^2.0.1'
 
 dependency_overrides:

--- a/json_dynamic_widget/pubspec.yaml
+++ b/json_dynamic_widget/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget'
 description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
 repository: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/json_dynamic_widget'
-version: '7.3.1+11'
+version: '7.3.1+12'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -13,8 +13,8 @@ analyzer:
 dependencies:
   child_builder: '^2.0.2'
   collection: '^1.17.1'
-  dynamic_widget_annotation: '^1.1.2+8'
-  execution_timer: '^1.1.0+8'
+  dynamic_widget_annotation: '^1.1.2+9'
+  execution_timer: '^1.1.0+10'
   flutter:
     sdk: 'flutter'
   form_validation: '^3.2.0'
@@ -25,7 +25,7 @@ dependencies:
   json_theme: '^6.5.4'
   logging: '^1.3.0'
   meta: '^1.12.0'
-  template_expressions: '^3.3.1'
+  template_expressions: '^3.3.1+1'
   uuid: '^4.1.0'
   yaml_writer: '^2.0.1'
   yaon: '^1.1.4+10'
@@ -35,7 +35,7 @@ dev_dependencies:
   flutter_lints: '^5.0.0'
   flutter_test:
     sdk: 'flutter'
-  json_dynamic_widget_codegen: '^1.0.6+15'
+  json_dynamic_widget_codegen: '^1.0.6+16'
 
 dependency_overrides:
   json_dynamic_widget_codegen:


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.25.9 --> 1.25.10


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.2+8 --> 1.1.2+9
  * `template_expressions`: 3.3.1 --> 3.3.1+1


Analysis Successful


dependencies:
  * `dynamic_widget_annotation`: 1.1.2+8 --> 1.1.2+9
  * `execution_timer`: 1.1.0+8 --> 1.1.0+10
  * `template_expressions`: 3.3.1 --> 3.3.1+1

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.6+15 --> 1.0.6+16


Analysis Successful


dependencies:
  * `execution_timer`: 1.1.0+8 --> 1.1.0+10

dev_dependencies:
  * `json_dynamic_widget_codegen`: 1.0.6+15 --> 1.0.6+16


Analysis Successful

