### PR TITLE
feat: Allow newer versions of analyzer

### DIFF
--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.0+1] - December 20th, 2024
+
+* Compatibility with analyzer `>= 6.5.0`
+
+
 ## [2.0.0] - December 12th, 2024
 
 * Flutter 3.27

--- a/packages/codegen/pubspec.yaml
+++ b/packages/codegen/pubspec.yaml
@@ -13,7 +13,7 @@ analyzer:
     - 'lib/**/*.g.dart'
 
 dependencies:
-  analyzer: '>=6.2.0 <6.5.0'
+  analyzer: '^6.2.0'
   build: '^2.4.1'
   code_builder: '^4.10.1'
   dynamic_widget_annotation: '^2.0.0'

--- a/packages/codegen/pubspec.yaml
+++ b/packages/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_dynamic_widget_codegen'
 description: 'A library autogenerate JSON widget builders.'
 homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget/tree/main/codegen'
-version: '2.0.0'
+version: '2.0.0+1'
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Description

Currently we cannot update to flutter 3.27.x, as this package conflicts with `freezed`.

```
Because no versions of freezed match >2.5.7 <3.0.0 and freezed 2.5.7 depends on analyzer ^6.5.0, freezed ^2.5.7 requires analyzer ^6.5.0.
And because json_dynamic_widget_codegen >=1.0.6+1 depends on analyzer >=6.2.0 <6.5.0, freezed ^2.5.7 is incompatible with json_dynamic_widget_codegen >=1.0.6+1.
So, because swi_plus_design_system depends on both json_dynamic_widget_codegen ^2.0.0 and freezed ^2.5.7, version solving failed.
```

Generally it should be found a workaround to not limit greater package versions, but find a workaround to handle these in the code via a check.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
