### PR TITLE
dupe widgets code gen issue widget_metadata.dart

### DIFF
--- a/packages/codegen/lib/src/util/widget_metadata.dart
+++ b/packages/codegen/lib/src/util/widget_metadata.dart
@@ -9,10 +9,16 @@ class WidgetMetadata {
 
   List<WidgetInfo> get data {
     final result = List<WidgetInfo>.from(_cache);
-
     result.sort();
-
-    return result;
+    // I find the generated default_registrar.g.dart file will often have dupes 
+    // without this code to dedupe the widget list, not sure why !
+    // (for example, ..withAlign()..withAlign() etc repeated over and over
+    final mm = <String, WidgetInfo>{};
+    for (var x in result) {
+      if (!mm.containsKey(x.builder)) mm[x.builder] = x;
+    }
+    return mm.values.toList();
+    // return result;
   }
 
   void add({


### PR DESCRIPTION
I was having syntax errors in the generated default_registrar.g.dart file, and the reason was that there were dupes for all the widgets.  The "void withAlign() {" method was repeated over and over as well as all the others. It seemed to add another copy each time the generator ran as if something was "building up".

I took a stab at deduping the widget list and I am not seeing the issue anymore.

I really have no idea out code gen stuff works so not idea if this is actually a good solution or what the root cause is.

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated `CHANGELOG.md` to add a description of the change.
- [ ] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [ ] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
