### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/packages/codegen/CHANGELOG.md
+++ b/packages/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.0.0+1] - September 2, 2025
+
+* Automated dependency updates
+
+
 ## [3.0.0] - June 17th, 2025
 
 * Updated `flutter_lints` to `^6.0.0`.

--- a/packages/codegen/pubspec.yaml
+++ b/packages/codegen/pubspec.yaml
@@ -1,79 +1,79 @@
-name: 'json_dynamic_widget_codegen'
-description: 'A library autogenerate JSON widget builders.'
-homepage: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '3.0.0'
+name: "json_dynamic_widget_codegen"
+description: "A library autogenerate JSON widget builders."
+homepage: "https://github.com/peiffer-innovations/json_dynamic_widget"
+version: "3.0.0+1"
 
 environment:
-  sdk: '^3.8.1'
-resolution: 'workspace'
+  sdk: "^3.8.1"
+resolution: "workspace"
 
 analyzer:
   exclude:
-    - 'lib/generated/**'
-    - 'lib/**/*.g.dart'
+    - "lib/generated/**"
+    - "lib/**/*.g.dart"
 
 dependencies:
-  analyzer: '>=6.2.0 <7.4.0'
-  build: '^2.4.2'
-  code_builder: '^4.10.1'
-  dynamic_widget_annotation: '^3.0.0'
-  json_class: '^3.0.1'
-  json_theme: '^9.0.0+1'
-  recase: '^4.1.0'
-  source_gen: '^2.0.0'
-  template_expressions: '^3.3.1+2'
-  yaml_writer: '^2.1.0'
-  yaon: '^1.1.4+10'
+  analyzer: ">=6.2.0 <7.4.0"
+  build: "^3.0.2"
+  code_builder: "^4.10.1"
+  dynamic_widget_annotation: "^3.0.0"
+  json_class: "^3.0.1"
+  json_theme: "^9.0.1+2"
+  recase: "^4.1.0"
+  source_gen: "^4.0.0"
+  template_expressions: "^3.3.1+2"
+  yaml_writer: "^2.1.0"
+  yaon: "^1.1.4+10"
 
 dev_dependencies:
-  flutter_lints: '^6.0.0'
-  test: '^1.25.2'
+  flutter_lints: "^6.0.0"
+  test: "^1.25.2"
 
 permittedLicenses:
-  - 'Apache-2.0'
-  - 'BSD-2-Clause'
-  - 'BSD-3-Clause'
-  - 'MIT'
-  - 'MIT-Modern-Variant'
-  - 'MPL-2.0'
-  - 'Zlib'
+  - "Apache-2.0"
+  - "BSD-2-Clause"
+  - "BSD-3-Clause"
+  - "MIT"
+  - "MIT-Modern-Variant"
+  - "MPL-2.0"
+  - "Zlib"
 
 packageLicenseOverride:
-  flutter: 'BSD-3-Clause'
-  flutter_driver: 'BSD-3-Clause'
-  flutter_goldens: 'BSD-3-Clause'
-  flutter_localizations: 'BSD-3-Clause'
-  flutter_web_plugins: 'BSD-3-Clause'
-  flutter_test: 'BSD-3-Clause'
-  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
-  integration_test: 'BSD-3-Clause'
-  rxdart: 'Apache-2.0'
-  sky_engine: 'BSD-3-Clause'
+  flutter: "BSD-3-Clause"
+  flutter_driver: "BSD-3-Clause"
+  flutter_goldens: "BSD-3-Clause"
+  flutter_localizations: "BSD-3-Clause"
+  flutter_web_plugins: "BSD-3-Clause"
+  flutter_test: "BSD-3-Clause"
+  fuchsia_remote_debug_protocol: "BSD-3-Clause"
+  integration_test: "BSD-3-Clause"
+  rxdart: "Apache-2.0"
+  sky_engine: "BSD-3-Clause"
 
 ignore_updates:
-  - 'analyzer'
-  - 'archive'
-  - 'async'
-  - 'boolean_selector'
-  - 'characters'
-  - 'charcode'
-  - 'collection'
-  - 'clock'
-  - 'crypto'
-  - 'fake_async'
-  - 'file'
-  - 'matcher'
-  - 'material_color_utilities'
-  - 'meta'
-  - 'path'
-  - 'source_span'
-  - 'stack_trace'
-  - 'stream_channel'
-  - 'string_scanner'
-  - 'sync_http'
-  - 'term_glyph'
-  - 'test'
-  - 'test_api'
-  - 'typed_data'
-  - 'vector_math'
-  - 'webdriver'
+  - "analyzer"
+  - "archive"
+  - "async"
+  - "boolean_selector"
+  - "characters"
+  - "charcode"
+  - "collection"
+  - "clock"
+  - "crypto"
+  - "fake_async"
+  - "file"
+  - "matcher"
+  - "material_color_utilities"
+  - "meta"
+  - "path"
+  - "source_span"
+  - "stack_trace"
+  - "stream_channel"
+  - "string_scanner"
+  - "sync_http"
+  - "term_glyph"
+  - "test"
+  - "test_api"
+  - "typed_data"
+  - "vector_math"
+  - "webdriver"

--- a/packages/json_dynamic_widget/CHANGELOG.md
+++ b/packages/json_dynamic_widget/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [10.0.2+1] - September 2, 2025
+
+* Automated dependency updates
+
+
 ## [10.0.2] - July 14th, 2025
 
 * Fix for TextFormField.autofillHints typing

--- a/packages/json_dynamic_widget/example/pubspec.yaml
+++ b/packages/json_dynamic_widget/example/pubspec.yaml
@@ -1,38 +1,38 @@
-name: 'json_dynamic_widget_example'
-description: 'Example app for the JsonDynamicWidget library'
-publish_to: 'none'
-version: '1.0.0+90'
+name: "json_dynamic_widget_example"
+description: "Example app for the JsonDynamicWidget library"
+publish_to: "none"
+version: "1.0.0+91"
 
 environment:
-  sdk: '^3.8.1'
-resolution: 'workspace'
+  sdk: "^3.8.1"
+resolution: "workspace"
 
 dependencies:
-  child_builder: '^2.0.2'
-  desktop_window: '^0.4.2'
-  dotted_border: '^2.1.0'
-  execution_timer: '^1.1.0+13'
+  child_builder: "^2.0.2"
+  desktop_window: "^0.4.2"
+  dotted_border: "^3.1.0"
+  execution_timer: "^1.1.0+13"
   flutter:
-    sdk: 'flutter'
-  flutter_svg: '^2.1.0'
-  json_class: '^3.0.1'
+    sdk: "flutter"
+  flutter_svg: "^2.2.0"
+  json_class: "^3.0.1"
   json_dynamic_widget:
-    path: '../'
-  json_theme: '^9.0.0+1'
-  logging: '^1.3.0'
-  yaon: '^1.1.4+10'
+    path: "../"
+  json_theme: "^9.0.1+2"
+  logging: "^1.3.0"
+  yaon: "^1.1.4+10"
 
 dev_dependencies:
-  build_runner: '^2.4.15'
-  flutter_lints: '^6.0.0'
+  build_runner: "^2.7.0"
+  flutter_lints: "^6.0.0"
   flutter_test:
-    sdk: 'flutter'
-  icons_launcher: '^3.0.1'
-  json_dynamic_widget_codegen: '^3.0.0'
-  yaml_writer: '^2.1.0'
+    sdk: "flutter"
+  icons_launcher: "^3.0.2"
+  json_dynamic_widget_codegen: "^3.0.0"
+  yaml_writer: "^2.1.0"
 
 icons_launcher:
-  image_path: 'assets-src/icon.png'
+  image_path: "assets-src/icon.png"
   platforms:
     android:
       enable: true
@@ -50,59 +50,59 @@ icons_launcher:
 flutter:
   uses-material-design: true
   assets:
-    - 'assets/images/'
-    - 'assets/pages/'
-    - 'assets/secrets/'
-    - 'assets/widgets/'
+    - "assets/images/"
+    - "assets/pages/"
+    - "assets/secrets/"
+    - "assets/widgets/"
   fonts:
-    - family: 'lato'
+    - family: "lato"
       fonts:
-        - asset: 'assets/fonts/Lato-Regular.ttf'
-    - family: 'metal'
+        - asset: "assets/fonts/Lato-Regular.ttf"
+    - family: "metal"
       fonts:
-        - asset: 'assets/fonts/MetalMania-Regular.ttf'
+        - asset: "assets/fonts/MetalMania-Regular.ttf"
 
 permittedLicenses:
-  - 'Apache-2.0'
-  - 'BSD-2-Clause'
-  - 'BSD-3-Clause'
-  - 'MIT'
-  - 'MIT-Modern-Variant'
-  - 'MPL-2.0'
-  - 'Zlib'
+  - "Apache-2.0"
+  - "BSD-2-Clause"
+  - "BSD-3-Clause"
+  - "MIT"
+  - "MIT-Modern-Variant"
+  - "MPL-2.0"
+  - "Zlib"
 
 packageLicenseOverride:
-  flutter: 'BSD-3-Clause'
-  flutter_driver: 'BSD-3-Clause'
-  flutter_goldens: 'BSD-3-Clause'
-  flutter_localizations: 'BSD-3-Clause'
-  flutter_web_plugins: 'BSD-3-Clause'
-  flutter_test: 'BSD-3-Clause'
-  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
-  integration_test: 'BSD-3-Clause'
+  flutter: "BSD-3-Clause"
+  flutter_driver: "BSD-3-Clause"
+  flutter_goldens: "BSD-3-Clause"
+  flutter_localizations: "BSD-3-Clause"
+  flutter_web_plugins: "BSD-3-Clause"
+  flutter_test: "BSD-3-Clause"
+  fuchsia_remote_debug_protocol: "BSD-3-Clause"
+  integration_test: "BSD-3-Clause"
 
 ignore_updates:
-  - 'archive'
-  - 'async'
-  - 'boolean_selector'
-  - 'characters'
-  - 'charcode'
-  - 'collection'
-  - 'clock'
-  - 'crypto'
-  - 'fake_async'
-  - 'file'
-  - 'matcher'
-  - 'material_color_utilities'
-  - 'meta'
-  - 'path'
-  - 'source_span'
-  - 'stack_trace'
-  - 'stream_channel'
-  - 'string_scanner'
-  - 'sync_http'
-  - 'term_glyph'
-  - 'test_api'
-  - 'typed_data'
-  - 'vector_math'
-  - 'webdriver'
+  - "archive"
+  - "async"
+  - "boolean_selector"
+  - "characters"
+  - "charcode"
+  - "collection"
+  - "clock"
+  - "crypto"
+  - "fake_async"
+  - "file"
+  - "matcher"
+  - "material_color_utilities"
+  - "meta"
+  - "path"
+  - "source_span"
+  - "stack_trace"
+  - "stream_channel"
+  - "string_scanner"
+  - "sync_http"
+  - "term_glyph"
+  - "test_api"
+  - "typed_data"
+  - "vector_math"
+  - "webdriver"

--- a/packages/json_dynamic_widget/pubspec.yaml
+++ b/packages/json_dynamic_widget/pubspec.yaml
@@ -1,87 +1,87 @@
-name: 'json_dynamic_widget'
-description: 'A library to dynamically generate widgets within Flutter from JSON or other Map-like structures.'
-repository: 'https://github.com/peiffer-innovations/json_dynamic_widget'
-version: '10.0.2'
+name: "json_dynamic_widget"
+description: "A library to dynamically generate widgets within Flutter from JSON or other Map-like structures."
+repository: "https://github.com/peiffer-innovations/json_dynamic_widget"
+version: "10.0.2+1"
 
 environment:
-  sdk: '^3.7.0'
-resolution: 'workspace'
+  sdk: "^3.7.0"
+resolution: "workspace"
 
 analyzer:
   exclude:
-    - 'lib/generated/**'
+    - "lib/generated/**"
 
 dependencies:
-  child_builder: '^2.0.2'
-  collection: '^1.17.1'
-  dynamic_widget_annotation: '^3.0.0'
-  execution_timer: '^1.1.0+13'
+  child_builder: "^2.0.2"
+  collection: "^1.17.1"
+  dynamic_widget_annotation: "^3.0.0"
+  execution_timer: "^1.1.0+13"
   flutter:
-    sdk: 'flutter'
-  form_validation: '^3.2.0'
-  interpolation: '^2.1.2'
-  json_class: '^3.0.1'
-  json_conditional: '^3.0.1+17'
-  json_schema: '^5.2.1'
-  json_theme: '^9.0.0+1'
-  logging: '^1.3.0'
-  meta: '^1.16.0'
-  template_expressions: '^3.3.1+2'
-  uuid: '^4.1.0'
-  yaml_writer: '^2.1.0'
-  yaon: '^1.1.4+10'
+    sdk: "flutter"
+  form_validation: "^3.2.0"
+  interpolation: "^2.1.2"
+  json_class: "^3.0.1"
+  json_conditional: "^3.0.1+17"
+  json_schema: "^5.2.1"
+  json_theme: "^9.0.1+2"
+  logging: "^1.3.0"
+  meta: "^1.16.0"
+  template_expressions: "^3.3.1+2"
+  uuid: "^4.1.0"
+  yaml_writer: "^2.1.0"
+  yaon: "^1.1.4+10"
 
 dev_dependencies:
-  build_runner: '^2.4.15'
-  flutter_lints: '^6.0.0'
+  build_runner: "^2.7.0"
+  flutter_lints: "^6.0.0"
   flutter_test:
-    sdk: 'flutter'
-  json_dynamic_widget_codegen: '^3.0.0'
+    sdk: "flutter"
+  json_dynamic_widget_codegen: "^3.0.0"
 
 permittedLicenses:
-  - 'Apache-2.0'
-  - 'BSD-2-Clause'
-  - 'BSD-3-Clause'
-  - 'MIT'
-  - 'MIT-Modern-Variant'
-  - 'MPL-2.0'
-  - 'Zlib'
+  - "Apache-2.0"
+  - "BSD-2-Clause"
+  - "BSD-3-Clause"
+  - "MIT"
+  - "MIT-Modern-Variant"
+  - "MPL-2.0"
+  - "Zlib"
 
 packageLicenseOverride:
-  flutter: 'BSD-3-Clause'
-  flutter_driver: 'BSD-3-Clause'
-  flutter_goldens: 'BSD-3-Clause'
-  flutter_localizations: 'BSD-3-Clause'
-  flutter_web_plugins: 'BSD-3-Clause'
-  flutter_test: 'BSD-3-Clause'
-  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
-  integration_test: 'BSD-3-Clause'
-  rxdart: 'Apache-2.0'
-  sky_engine: 'BSD-3-Clause'
+  flutter: "BSD-3-Clause"
+  flutter_driver: "BSD-3-Clause"
+  flutter_goldens: "BSD-3-Clause"
+  flutter_localizations: "BSD-3-Clause"
+  flutter_web_plugins: "BSD-3-Clause"
+  flutter_test: "BSD-3-Clause"
+  fuchsia_remote_debug_protocol: "BSD-3-Clause"
+  integration_test: "BSD-3-Clause"
+  rxdart: "Apache-2.0"
+  sky_engine: "BSD-3-Clause"
 
 ignore_updates:
-  - 'archive'
-  - 'async'
-  - 'boolean_selector'
-  - 'characters'
-  - 'charcode'
-  - 'collection'
-  - 'clock'
-  - 'crypto'
-  - 'fake_async'
-  - 'file'
-  - 'matcher'
-  - 'material_color_utilities'
-  - 'meta'
-  - 'path'
-  - 'source_span'
-  - 'stack_trace'
-  - 'stream_channel'
-  - 'string_scanner'
-  - 'sync_http'
-  - 'term_glyph'
-  - 'test_api'
-  - 'typed_data'
-  - 'uuid'
-  - 'vector_math'
-  - 'webdriver'
+  - "archive"
+  - "async"
+  - "boolean_selector"
+  - "characters"
+  - "charcode"
+  - "collection"
+  - "clock"
+  - "crypto"
+  - "fake_async"
+  - "file"
+  - "matcher"
+  - "material_color_utilities"
+  - "meta"
+  - "path"
+  - "source_span"
+  - "stack_trace"
+  - "stream_channel"
+  - "string_scanner"
+  - "sync_http"
+  - "term_glyph"
+  - "test_api"
+  - "typed_data"
+  - "uuid"
+  - "vector_math"
+  - "webdriver"


### PR DESCRIPTION
PR created automatically



dependencies:
  * `build`: 2.4.2 --> 3.0.2
  * `json_theme`: 9.0.0+1 --> 9.0.1+2
  * `source_gen`: 2.0.0 --> 4.0.0


Error!!!
```
Resolving dependencies in `/home/runner/work/json_dynamic_widget/json_dynamic_widget`...


Because source_gen >=3.1.0 depends on analyzer >=7.4.0 <9.0.0 and json_dynamic_widget_codegen depends on analyzer >=6.2.0 <7.4.0, source_gen >=3.1.0 is forbidden.
So, because json_dynamic_widget_codegen depends on source_gen ^4.0.0, version solving failed.

```


dependencies:
  * `json_theme`: 9.0.0+1 --> 9.0.1+2

dev_dependencies:
  * `build_runner`: 2.4.15 --> 2.7.0


Error!!!
```
Resolving dependencies in `/home/runner/work/json_dynamic_widget/json_dynamic_widget`...


Because source_gen >=3.1.0 depends on analyzer >=7.4.0 <9.0.0 and json_dynamic_widget_codegen depends on analyzer >=6.2.0 <7.4.0, source_gen >=3.1.0 is forbidden.
So, because json_dynamic_widget_codegen depends on source_gen ^4.0.0, version solving failed.
Failed to update packages.

```


dependencies:
  * `dotted_border`: 2.1.0 --> 3.1.0
  * `flutter_svg`: 2.1.0 --> 2.2.0
  * `json_theme`: 9.0.0+1 --> 9.0.1+2

dev_dependencies:
  * `build_runner`: 2.4.15 --> 2.7.0
  * `icons_launcher`: 3.0.1 --> 3.0.2


Error!!!
```
Resolving dependencies in `/home/runner/work/json_dynamic_widget/json_dynamic_widget`...


Because source_gen >=3.1.0 depends on analyzer >=7.4.0 <9.0.0 and json_dynamic_widget_codegen depends on analyzer >=6.2.0 <7.4.0, source_gen >=3.1.0 is forbidden.
So, because json_dynamic_widget_codegen depends on source_gen ^4.0.0, version solving failed.
Failed to update packages.

```

